### PR TITLE
[example] books.rs, put search within timing start/end

### DIFF
--- a/examples/books.rs
+++ b/examples/books.rs
@@ -29,10 +29,11 @@ fn main() -> io::Result<()> {
 
         let start = Instant::now();
         let pattern = pattern.replace("\r\n", "");
+        let res = engine.search(&pattern);
         let end = Instant::now();
 
         println!("pattern: {:?}", &pattern);
-        println!("results: {:?}", engine.search(&pattern));
+        println!("results: {:?}", res);
         println!("time: {:?}", end - start);
     }
 }


### PR DESCRIPTION
From what I can see, the timing in the books example only times the pattern replace, and not the search itself.