### PR TITLE
strip whitespace from user input in example

### DIFF
--- a/examples/books.rs
+++ b/examples/books.rs
@@ -31,7 +31,7 @@ fn main() -> io::Result<()> {
         let res = engine.search(&pattern);
         let end = Instant::now();
 
-        println!("pattern: {:?}", &pattern);
+        println!("pattern: {:?}", pattern.trim());
         println!("results: {:?}", res);
         println!("time: {:?}", end - start);
     }


### PR DESCRIPTION
The standard behavior of `read_line` leaves the newline from the user pressing the enter key. This PR strips that newline before performing the search.