### PR TITLE
Added SIMD-accelerated Levenshtein distance support based on the `triple_accel` library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,7 @@ dependencies = [
  "quickcheck 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "triple_accel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -550,6 +551,11 @@ dependencies = [
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "triple_accel"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ucd-util"
@@ -674,6 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tinytemplate 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7655088894274afb52b807bd3c87072daa1fedd155068b8705cabfd628956115"
+"checksum triple_accel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "954f434737686bf6028366022b92fcba3143c09e99c1a9bcb6c18fb9f970b047"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "quickcheck 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "triple_accel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "triple_accel 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "triple_accel"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -680,7 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tinytemplate 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7655088894274afb52b807bd3c87072daa1fedd155068b8705cabfd628956115"
-"checksum triple_accel 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "954f434737686bf6028366022b92fcba3143c09e99c1a9bcb6c18fb9f970b047"
+"checksum triple_accel 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1823217b82713b5b3f14d1ee626d1480efa0aa2487bddb8b17d465d122dfc590"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "quickcheck 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "triple_accel 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "triple_accel 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "triple_accel"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -680,7 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tinytemplate 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7655088894274afb52b807bd3c87072daa1fedd155068b8705cabfd628956115"
-"checksum triple_accel 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1823217b82713b5b3f14d1ee626d1480efa0aa2487bddb8b17d465d122dfc590"
+"checksum triple_accel 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9cef429eb300c9dbe7f9bb1b7dde13547ed2ba8f9fe07ff1db885c2d760cef4f"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["algorithms", "text-processing"]
 
 [dependencies]
 strsim = "0.10"
-triple_accel = "0.2.1"
+triple_accel = "0.2.2"
 
 [dev-dependencies]
 json = "0.11.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["algorithms", "text-processing"]
 
 [dependencies]
 strsim = "0.10"
+triple_accel = "0.2.0"
 
 [dev-dependencies]
 json = "0.11.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["algorithms", "text-processing"]
 
 [dependencies]
 strsim = "0.10"
-triple_accel = "0.2.0"
+triple_accel = "0.2.1"
 
 [dev-dependencies]
 json = "0.11.13"

--- a/README.md
+++ b/README.md
@@ -39,14 +39,6 @@ use simsearch::{SimSearch, SearchOptions};
 
 let options = SearchOptions::new().levenshtein(true);
 let mut engine: SimSearch<u32> = SimSearch::new_with(options);
-
-engine.insert(1, "Things Fall Apart");
-engine.insert(2, "The Old Man and the Sea");
-engine.insert(3, "James Joyce");
-
-let results: Vec<u32> = engine.search("thngs");
-
-assert_eq!(results, &[1]);
 ```
 
 Also try the interactive demo by:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ let results: Vec<u32> = engine.search("thngs");
 
 assert_eq!(results, &[1]);
 ```
-By default, Jaro-Winkler distance is used. SIMD-accelerated Levenshtein distance
-for ASCII byte strings is also supported by specifying custom `SearchOptions`:
+
+By default, Jaro-Winkler distance is used. An alternative Levenshtein distance,
+which is SIMD-accelerated but only works for ASCII byte strings, can be specified
+with custom `SearchOptions`:
+
 ```rust
 use simsearch::{SimSearch, SearchOptions};
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ let results: Vec<u32> = engine.search("thngs");
 
 assert_eq!(results, &[1]);
 ```
+By default, Jaro-Winkler distance is used. SIMD-accelerated Levenshtein distance
+for ASCII byte strings is also supported by specifying custom `SearchOptions`:
+```rust
+use simsearch::{SimSearch, SearchOptions};
+
+let options = SearchOptions::new().levenshtein(true);
+let mut engine: SimSearch<u32> = SimSearch::new_with(options);
+
+engine.insert(1, "Things Fall Apart");
+engine.insert(2, "The Old Man and the Sea");
+engine.insert(3, "James Joyce");
+
+let results: Vec<u32> = engine.search("thngs");
+
+assert_eq!(results, &[1]);
+```
 
 Also try the interactive demo by:
 

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use json;
-use simsearch::SimSearch;
+use simsearch::{SimSearch, SearchOptions};
 
 /// Loads content of a 'books.json' file into a JsonValue.
 fn load_content() -> json::JsonValue {
@@ -34,8 +34,19 @@ fn bench_engine(c: &mut Criterion) {
             BatchSize::SmallInput,
         )
     });
-    c.bench_function("search", |bencher| {
+    c.bench_function("search_jaro_winkler", |bencher| {
         let mut engine = SimSearch::new();
+        let j = load_content();
+
+        for title in j.members() {
+            engine.insert(title.as_str().unwrap(), title.as_str().unwrap());
+        }
+
+        bencher.iter(|| engine.search("odl sea"));
+    });
+    c.bench_function("search_levenshtein", |bencher| {
+        let options = SearchOptions::new().levenshtein(true);
+        let mut engine = SimSearch::new_with(options);
         let j = load_content();
 
         for title in j.members() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,21 +16,16 @@
 //!
 //! assert_eq!(results, &[1]);
 //! ```
-//! By default, Jaro-Winkler distance is used. SIMD-accelerated Levenshtein distance
-//! for ASCII byte strings is also supported by specifying custom `SearchOptions`:
+//!
+//! By default, Jaro-Winkler distance is used. An alternative Levenshtein distance, which is
+//! SIMD-accelerated but only works for ASCII byte strings, can be specified with `SearchOptions`:
+//!
 //! ```
 //! use simsearch::{SimSearch, SearchOptions};
 //!
 //! let options = SearchOptions::new().levenshtein(true);
 //! let mut engine: SimSearch<u32> = SimSearch::new_with(options);
 //!
-//! engine.insert(1, "Things Fall Apart");
-//! engine.insert(2, "The Old Man and the Sea");
-//! engine.insert(3, "James Joyce");
-//!
-//! let results: Vec<u32> = engine.search("thngs");
-//!
-//! assert_eq!(results, &[1]);
 //! ```
 
 use std;
@@ -399,13 +394,11 @@ impl SearchOptions {
         SearchOptions { threshold, ..self }
     }
 
-    /// Sets whether SIMD-accelerated Levenshtein distance should be used instead
-    /// of Jaro-Winkler distance.
+    /// Sets whether Levenshtein distance, which is SIMD-accelerated, should be
+    /// used instead of the default Jaro-Winkler distance.
     ///
-    /// For Levenshtein distance, insertions, deletions, and substitutions have an
-    /// associated unit cost. The underlying Levenshtein distance implementation is
-    /// very fast, but it cannot handle unicode strings, unlike the default
-    /// Jaro-Winkler distance.
+    /// The implementation of Levenshtein distance is very fast but cannot handle Unicode
+    /// strings, unlike the default Jaro-Winkler distance.
     ///
     /// Defaults to `false`.
     pub fn levenshtein(self, levenshtein: bool) -> Self {


### PR DESCRIPTION
I added support for Levenshtein distance by using the [triple_accel](https://crates.io/crates/triple_accel/) library. Levenshtein distance can be optionally enabled by the user by using `SearchOptions`. I also edited the readme, documentation, and benchmarks to reflect this change. I tried to follow the existing code style. The code passes all tests on my laptop, and for reference, here is an overview of the benchmark results:
```
add books: ~1.4 ms
search_jaro_winkler: ~212 us
search_levenshtein: ~131 us
```
SIMD Levenshtein distance should be even faster with longer strings.