### PR TITLE
feat: add `clear()` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,8 +272,8 @@ where
         result_ids
     }
 
-    /// Deletes entry by id.
-    pub fn delete(&mut self, id: &Id) {
+    /// Remove an entry by id.
+    pub fn remove(&mut self, id: &Id) {
         if let Some(id_num) = self.ids_map.get(id) {
             for token in &self.forward_map[id_num] {
                 self.reverse_map
@@ -287,8 +287,8 @@ where
         };
     }
 
-    /// Removes all entries and resets the search state.
-    pub fn reset(&mut self) {
+    /// Clear all entries.
+    pub fn clear(&mut self) {
         self.forward_map.clear();
         self.reverse_map.clear();
         self.ids_map.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,15 @@ where
         };
     }
 
+    /// Removes all entries and resets the search state.
+    pub fn reset(&mut self) {
+        self.forward_map.clear();
+        self.reverse_map.clear();
+        self.ids_map.clear();
+        self.reverse_ids_map.clear();
+        self.id_num_counter = 0;
+    }
+
     fn tokenize(&self, tokens: &[&str]) -> Vec<String> {
         let tokens: Vec<String> = tokens
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ where
     /// engine.insert_tokens("Arya Stark", &["Arya Stark", "a fictional
     /// character in American author George R. R", "portrayed by English actress."]);
     pub fn insert_tokens(&mut self, id: Id, tokens: &[&str]) {
-        self.delete(&id);
+        self.remove(&id);
 
         let id_num = self.id_num_counter;
         self.ids_map.insert(id.clone(), id_num);


### PR DESCRIPTION
Pretty much does what it says on the tin :) I'm using this crate in a fuzzy file finder and need to clear the search state when I change a directory, so a method like this would be useful. Currently, I just [make a brand new `SimSearch` struct](https://git.kittencollective.com/nebkor/joecalsend/src/commit/e0738db7d28962d9c1d4bc7df7560e4aad527330/src/app/mod.rs#L201) when I need to reset.