### PR TITLE
feat: redesign search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ can be indexed from multiple parts without custom tokenization.
   by a threshold; callers can filter by `Hit::score` when needed.
 - Removed configurable matching metrics and `SearchOptions::levenshtein(...)`.
   Typo tolerance now uses Jaro-Winkler similarity internally.
-- Replaced tokenizer options with `Options::separators(...)`, which sets the
-  full separator list. By default, separators are
-  [`char::is_ascii_whitespace`](https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii_whitespace)
+- Replaced tokenizer options with `Options::separators(...)`, which adds
+  separators beyond the default
+  [`char::is_whitespace`](https://doc.rust-lang.org/std/primitive.char.html#method.is_whitespace)
   characters.
 - Added a default result limit of 10. Use `Options::limit(...)` to change it.
 - Removed the `Ord` requirement for IDs. IDs now need `Eq + Clone + Hash`;
@@ -34,7 +34,7 @@ can be indexed from multiple parts without custom tokenization.
 - `Index::insert_parts(id, parts)` for indexing multiple searchable parts.
 - `Options::limit(...)` for controlling result count.
 - `Options::prefix_search(...)` for controlling last-token prefix matching.
-- `Options::typo_tolerance(...)` for controlling bounded typo matching.
+- `Options::typo_tolerance(...)` for controlling typo-tolerant matching.
 - Scores in the interactive `books` example.
 
 ### Changed
@@ -159,18 +159,11 @@ let options = SearchOptions::new()
 After:
 
 ```rust
-let mut separators: Vec<char> = (0..=u8::MAX)
-    .map(char::from)
-    .filter(char::is_ascii_whitespace)
-    .collect();
-separators.push('/');
-
-let options = Options::new().separators(separators);
+let options = Options::new().separators(['/']);
 ```
 
-`separators(...)` replaces the whole separator list. Include
-`char::is_ascii_whitespace` characters yourself if you want to keep the default
-whitespace behavior while adding custom separators.
+`separators(...)` adds separators on top of the default
+`char::is_whitespace` behavior.
 
 #### Update result limits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ can be indexed from multiple fields without custom tokenization.
 - Renamed `SearchOptions` to `Options`.
 - Renamed `SimSearch::new_with(...)` to `Index::with_options(...)`.
 - Changed `Index::search(...)` to return `Vec<Hit<Id>>` instead of `Vec<Id>`.
-- Removed `insert_tokens(...)` and `search_tokens(...)`.
+- Removed `insert_tokens(...)`, `search_tokens(...)`,
+  `search_with_scores(...)`, and `search_tokens_with_scores(...)`.
 - Added `insert_many(...)` for entries with multiple searchable fields.
 - Removed `SearchOptions::threshold(...)`. Search results are no longer filtered
   by a threshold; callers can filter by `Hit::score` when needed.
@@ -93,6 +94,9 @@ let ids: Vec<u32> = index
     .collect();
 ```
 
+The old scored search APIs are also replaced by `search(...)`; every returned
+hit includes both `id` and `score`.
+
 #### Replace token APIs with fields
 
 The old token APIs were often used to avoid manually concatenating several
@@ -133,6 +137,9 @@ let results: Vec<_> = index
     .filter(|hit| hit.score >= 0.8)
     .collect();
 ```
+
+Search applies `Options::limit(...)` before caller-side filtering. Increase the
+limit first if you need a larger candidate set before filtering by score.
 
 #### Update tokenizer options
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This release redesigns `simsearch` for embedded autocomplete and search
 suggestions. The public API is smaller, searches return scored hits, and entries
-can be indexed from multiple fields without custom tokenization.
+can be indexed from multiple parts without custom tokenization.
 
 ### Breaking Changes
 
@@ -14,7 +14,7 @@ can be indexed from multiple fields without custom tokenization.
 - Changed `Index::search(...)` to return `Vec<Hit<Id>>` instead of `Vec<Id>`.
 - Removed `insert_tokens(...)`, `search_tokens(...)`,
   `search_with_scores(...)`, and `search_tokens_with_scores(...)`.
-- Added `insert_many(...)` for entries with multiple searchable fields.
+- Added `insert_parts(...)` for entries with multiple searchable parts.
 - Removed `SearchOptions::threshold(...)`. Search results are no longer filtered
   by a threshold; callers can filter by `Hit::score` when needed.
 - Removed configurable matching metrics and `SearchOptions::levenshtein(...)`.
@@ -30,7 +30,7 @@ can be indexed from multiple fields without custom tokenization.
 ### Added
 
 - `Hit<Id>` with `id` and normalized `score`.
-- `Index::insert_many(id, fields)` for indexing multiple searchable fields.
+- `Index::insert_parts(id, parts)` for indexing multiple searchable parts.
 - `Options::limit(...)` for controlling result count.
 - `Options::prefix_search(...)` for controlling last-token prefix matching.
 - `Options::typo_tolerance(...)` for controlling bounded typo matching.
@@ -44,7 +44,7 @@ can be indexed from multiple fields without custom tokenization.
   `0.0..=1.0` range.
 - Low-quality matches are allowed, but they receive lower scores and rank behind
   stronger matches.
-- `insert(...)`, `insert_many(...)`, and `search(...)` all use the built-in
+- `insert(...)`, `insert_parts(...)`, and `search(...)` all use the built-in
   tokenizer.
 
 ### Migration Guide
@@ -101,10 +101,10 @@ let ids: Vec<u32> = index
 The old scored search APIs are also replaced by `search(...)`; every returned
 hit includes both `id` and `score`.
 
-#### Replace token APIs with fields
+#### Replace token APIs with parts
 
 The old token APIs were often used to avoid manually concatenating several
-document fields. Use `insert_many(...)` for that case.
+document parts. Use `insert_parts(...)` for that case.
 
 Before:
 
@@ -116,12 +116,12 @@ let results = index.search_tokens(&["hemingway"]);
 After:
 
 ```rust
-index.insert_many(1, ["The Old Man and the Sea", "Ernest Hemingway"]);
+index.insert_parts(1, ["The Old Man and the Sea", "Ernest Hemingway"]);
 let results = index.search("hemingway");
 ```
 
 There is no direct replacement for fully custom query tokenization. The index
-now intentionally uses one built-in tokenizer for both indexed fields and search
+now intentionally uses one built-in tokenizer for both indexed parts and search
 queries.
 
 #### Replace threshold filtering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ can be indexed from multiple parts without custom tokenization.
   by a threshold; callers can filter by `Hit::score` when needed.
 - Removed configurable matching metrics and `SearchOptions::levenshtein(...)`.
   Typo tolerance now uses Jaro-Winkler similarity internally.
-- Renamed tokenizer options:
-  - `stop_words(...)` is now `separators(...)`.
-  - `stop_whitespace(...)` is now `split_whitespace(...)`.
+- Replaced tokenizer options with `Options::separators(...)`, which sets the
+  full separator list. By default, separators are
+  [`char::is_ascii_whitespace`](https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii_whitespace)
+  characters.
 - Added a default result limit of 10. Use `Options::limit(...)` to change it.
 - Removed the `Ord` requirement for IDs. IDs now need `Eq + Clone + Hash`;
   equal-score ties are resolved by insertion order.
@@ -158,10 +159,18 @@ let options = SearchOptions::new()
 After:
 
 ```rust
-let options = Options::new()
-    .split_whitespace(true)
-    .separators(vec!["/".to_string()]);
+let mut separators: Vec<char> = (0..=u8::MAX)
+    .map(char::from)
+    .filter(char::is_ascii_whitespace)
+    .collect();
+separators.push('/');
+
+let options = Options::new().separators(separators);
 ```
+
+`separators(...)` replaces the whole separator list. Include
+`char::is_ascii_whitespace` characters yourself if you want to keep the default
+whitespace behavior while adding custom separators.
 
 #### Update result limits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ can be indexed from multiple parts without custom tokenization.
 - Removed `SearchOptions::threshold(...)`. Search results are no longer filtered
   by a threshold; callers can filter by `Hit::score` when needed.
 - Removed configurable matching metrics and `SearchOptions::levenshtein(...)`.
-  Typo tolerance now uses bounded edit distance internally.
+  Typo tolerance now uses Jaro-Winkler similarity internally.
 - Renamed tokenizer options:
   - `stop_words(...)` is now `separators(...)`.
   - `stop_whitespace(...)` is now `split_whitespace(...)`.
@@ -39,7 +39,7 @@ can be indexed from multiple parts without custom tokenization.
 ### Changed
 
 - Search now uses a positional inverted index with exact, last-token prefix,
-  typo-tolerant prefix, and bounded typo-tolerant term expansion.
+  typo-tolerant prefix, and Jaro-Winkler typo-tolerant term expansion.
 - Search results are ranked by a single normalized relevance score in the
   `0.0..=1.0` range.
 - Low-quality matches are allowed, but they receive lower scores and rank behind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ can be indexed from multiple fields without custom tokenization.
 - Added `insert_many(...)` for entries with multiple searchable fields.
 - Removed `SearchOptions::threshold(...)`. Search results are no longer filtered
   by a threshold; callers can filter by `Hit::score` when needed.
-- Removed Levenshtein matching and `SearchOptions::levenshtein(...)`.
-  Jaro-Winkler is now the only token similarity metric.
+- Removed configurable matching metrics and `SearchOptions::levenshtein(...)`.
+  Typo tolerance now uses bounded edit distance internally.
 - Renamed tokenizer options:
   - `stop_words(...)` is now `separators(...)`.
   - `stop_whitespace(...)` is now `split_whitespace(...)`.
@@ -32,10 +32,14 @@ can be indexed from multiple fields without custom tokenization.
 - `Hit<Id>` with `id` and normalized `score`.
 - `Index::insert_many(id, fields)` for indexing multiple searchable fields.
 - `Options::limit(...)` for controlling result count.
+- `Options::prefix_search(...)` for controlling last-token prefix matching.
+- `Options::typo_tolerance(...)` for controlling bounded typo matching.
 - Scores in the interactive `books` example.
 
 ### Changed
 
+- Search now uses a positional inverted index with exact, last-token prefix,
+  and bounded typo-tolerant term expansion.
 - Search results are ranked by a single normalized relevance score in the
   `0.0..=1.0` range.
 - Low-quality matches are allowed, but they receive lower scores and rank behind
@@ -139,7 +143,7 @@ let results: Vec<_> = index
 ```
 
 Search applies `Options::limit(...)` before caller-side filtering. Increase the
-limit first if you need a larger candidate set before filtering by score.
+limit first if you need more results before filtering by score.
 
 #### Update tokenizer options
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,162 @@
+# Changelog
+
+## 0.4.0
+
+This release redesigns `simsearch` for embedded autocomplete and search
+suggestions. The public API is smaller, searches return scored hits, and entries
+can be indexed from multiple fields without custom tokenization.
+
+### Breaking Changes
+
+- Renamed `SimSearch` to `Index`.
+- Renamed `SearchOptions` to `Options`.
+- Renamed `SimSearch::new_with(...)` to `Index::with_options(...)`.
+- Changed `Index::search(...)` to return `Vec<Hit<Id>>` instead of `Vec<Id>`.
+- Removed `insert_tokens(...)` and `search_tokens(...)`.
+- Added `insert_many(...)` for entries with multiple searchable fields.
+- Removed `SearchOptions::threshold(...)`. Search results are no longer filtered
+  by a threshold; callers can filter by `Hit::score` when needed.
+- Removed Levenshtein matching and `SearchOptions::levenshtein(...)`.
+  Jaro-Winkler is now the only token similarity metric.
+- Renamed tokenizer options:
+  - `stop_words(...)` is now `separators(...)`.
+  - `stop_whitespace(...)` is now `split_whitespace(...)`.
+- Added a default result limit of 10. Use `Options::limit(...)` to change it.
+- Removed the `Ord` requirement for IDs. IDs now need `Eq + Clone + Hash`;
+  equal-score ties are resolved by insertion order.
+- Bumped the crate to Rust 2024 edition and set MSRV to Rust 1.85.
+
+### Added
+
+- `Hit<Id>` with `id` and normalized `score`.
+- `Index::insert_many(id, fields)` for indexing multiple searchable fields.
+- `Options::limit(...)` for controlling result count.
+- Scores in the interactive `books` example.
+
+### Changed
+
+- Search results are ranked by a single normalized relevance score in the
+  `0.0..=1.0` range.
+- Low-quality matches are allowed, but they receive lower scores and rank behind
+  stronger matches.
+- `insert(...)`, `insert_many(...)`, and `search(...)` all use the built-in
+  tokenizer.
+
+### Migration Guide
+
+#### Rename the main types
+
+Before:
+
+```rust
+use simsearch::{SearchOptions, SimSearch};
+
+let options = SearchOptions::new();
+let mut index: SimSearch<u32> = SimSearch::new_with(options);
+```
+
+After:
+
+```rust
+use simsearch::{Index, Options};
+
+let options = Options::new();
+let mut index: Index<u32> = Index::with_options(options);
+```
+
+#### Read IDs from search hits
+
+`search(...)` now returns `Vec<Hit<Id>>`.
+
+Before:
+
+```rust
+let results: Vec<u32> = index.search("old sea");
+let first_id = results[0];
+```
+
+After:
+
+```rust
+let results = index.search("old sea");
+let first_id = results[0].id;
+let first_score = results[0].score;
+```
+
+If you only need IDs, map the hits:
+
+```rust
+let ids: Vec<u32> = index
+    .search("old sea")
+    .into_iter()
+    .map(|hit| hit.id)
+    .collect();
+```
+
+#### Replace token APIs with fields
+
+The old token APIs were often used to avoid manually concatenating several
+document fields. Use `insert_many(...)` for that case.
+
+Before:
+
+```rust
+index.insert_tokens(1, &["The Old Man and the Sea", "Ernest Hemingway"]);
+let results = index.search_tokens(&["hemingway"]);
+```
+
+After:
+
+```rust
+index.insert_many(1, ["The Old Man and the Sea", "Ernest Hemingway"]);
+let results = index.search("hemingway");
+```
+
+There is no direct replacement for fully custom query tokenization. The index
+now intentionally uses one built-in tokenizer for both indexed fields and search
+queries.
+
+#### Replace threshold filtering
+
+Before:
+
+```rust
+let options = SearchOptions::new().threshold(0.8);
+```
+
+After:
+
+```rust
+let results: Vec<_> = index
+    .search("old sea")
+    .into_iter()
+    .filter(|hit| hit.score >= 0.8)
+    .collect();
+```
+
+#### Update tokenizer options
+
+Before:
+
+```rust
+let options = SearchOptions::new()
+    .stop_whitespace(true)
+    .stop_words(vec!["/".to_string()]);
+```
+
+After:
+
+```rust
+let options = Options::new()
+    .split_whitespace(true)
+    .separators(vec!["/".to_string()]);
+```
+
+#### Update result limits
+
+Search now returns up to 10 results by default.
+
+```rust
+let options = Options::new().limit(20);
+let mut index = Index::with_options(options);
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ can be indexed from multiple parts without custom tokenization.
 ### Changed
 
 - Search now uses a positional inverted index with exact, last-token prefix,
-  and bounded typo-tolerant term expansion.
+  typo-tolerant prefix, and bounded typo-tolerant term expansion.
 - Search results are ranked by a single normalized relevance score in the
   `0.0..=1.0` range.
 - Low-quality matches are allowed, but they receive lower scores and rank behind

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,6 @@ dependencies = [
  "quickcheck_macros",
  "serde",
  "serde_json",
- "strsim",
 ]
 
 [[package]]
@@ -518,12 +517,6 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "quickcheck_macros",
  "serde",
  "serde_json",
+ "strsim",
 ]
 
 [[package]]
@@ -517,6 +518,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "simsearch"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "divan",
  "inquire",
@@ -511,7 +511,6 @@ dependencies = [
  "serde",
  "serde_json",
  "strsim",
- "triple_accel",
 ]
 
 [[package]]
@@ -555,12 +554,6 @@ checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "triple_accel"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22048bc95dfb2ffd05b1ff9a756290a009224b60b2f0e7525faeee7603851e63"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,8 @@ homepage = "https://github.com/andylokandy/simsearch-rs"
 readme = "README.md"
 exclude = ["books.json"]
 
-keywords = ["fuzzy", "search", "lightweight", "pattern", "strsim"]
+keywords = ["fuzzy", "search", "lightweight", "pattern", "autocomplete"]
 categories = ["algorithms", "text-processing"]
-
-[dependencies]
-strsim = "0.11"
 
 [dependencies.serde]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ exclude = ["books.json"]
 keywords = ["fuzzy", "search", "lightweight", "pattern", "autocomplete"]
 categories = ["algorithms", "text-processing"]
 
+[dependencies]
+strsim = "0.11"
+
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 name = "simsearch"
 version = "0.4.0"
 rust-version = "1.85"
-license = "MIT/Apache-2.0"
+license = "MIT"
 
 description = "A small in-memory fuzzy search index for embedded autocomplete and search suggestions."
 documentation = "https://docs.rs/simsearch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 authors = ["andylokandy <andylokandy@hotmail.com>"]
-edition = "2018"
+edition = "2024"
 name = "simsearch"
-version = "0.3.0"
+version = "0.4.0"
+rust-version = "1.85"
 license = "MIT/Apache-2.0"
 
-description = "A simple and lightweight fuzzy search engine that works in memory, searching for similar strings (a pun here)."
+description = "A small in-memory fuzzy search index for embedded autocomplete and search suggestions."
 documentation = "https://docs.rs/simsearch"
 repository = "https://github.com/andylokandy/simsearch-rs"
 homepage = "https://github.com/andylokandy/simsearch-rs"
@@ -17,7 +18,6 @@ categories = ["algorithms", "text-processing"]
 
 [dependencies]
 strsim = "0.11"
-triple_accel = "0.4"
 
 [dependencies.serde]
 version = "1.0"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 [![Build Status](https://travis-ci.com/andylokandy/simsearch-rs.svg?branch=master)](https://travis-ci.com/andylokandy/simsearch-rs)
 [![crates.io](https://img.shields.io/crates/v/simsearch.svg)](https://crates.io/crates/simsearch)
 [![docs.rs](https://docs.rs/simsearch/badge.svg)](https://docs.rs/simsearch)
+[![MSRV 1.85.0](https://img.shields.io/badge/MSRV-1.85.0-green?style=flat-square&logo=rust)](https://www.whatrustisit.com)
 
-A simple and lightweight fuzzy search engine that works in memory, searching for similar strings (a pun here).
+A small in-memory fuzzy search index for embedded autocomplete and search
+suggestions.
 
 ### [**Documentation**](https://docs.rs/simsearch)
 
@@ -14,34 +16,24 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-simsearch = "0.3"
+simsearch = "0.4"
 ```
 
 ## Example
 
 ```rust
-use simsearch::SimSearch;
+use simsearch::Index;
 
-let mut engine: SimSearch<u32> = SimSearch::new();
+let mut engine: Index<u32> = Index::new();
 
 engine.insert(1, "Things Fall Apart");
 engine.insert(2, "The Old Man and the Sea");
 engine.insert(3, "James Joyce");
 
-let results: Vec<u32> = engine.search("thngs");
+let results = engine.search("thngs");
 
-assert_eq!(results, &[1]);
-```
-
-By default, Jaro-Winkler distance is used. An alternative Levenshtein distance,
-which is SIMD-accelerated but only works for ASCII byte strings, can be specified
-with custom `SearchOptions`:
-
-```rust
-use simsearch::{SimSearch, SearchOptions};
-
-let options = SearchOptions::new().levenshtein(true);
-let mut engine: SimSearch<u32> = SimSearch::new_with(options);
+assert_eq!(results[0].id, 1);
+assert!(results[0].score > 0.0);
 ```
 
 Also try the interactive demo by:
@@ -54,7 +46,7 @@ $ cargo run --release --example books
 
 All kinds of contribution are welcomed.
 
-- **Issus.** Feel free to open an issue when you find typos, bugs, or have any question.
+- **Issues.** Feel free to open an issue when you find typos, bugs, or have any question.
 - **Pull requests**. New collection, better implementation, more tests, more documents and typo fixes are all welcomed.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ assert_eq!(results[0].id, 1);
 assert!(results[0].score > 0.0);
 ```
 
-Also try the interactive demo by:
+You can also try the interactive demo:
 
+```sh
+cargo run --release --example books
 ```
-$ cargo run --release --example books
-```
 
-## Contribution
+## Contributing
 
-All kinds of contribution are welcomed.
+Contributions are welcome.
 
-- **Issues.** Feel free to open an issue when you find typos, bugs, or have any question.
-- **Pull requests**. New collection, better implementation, more tests, more documents and typo fixes are all welcomed.
+- **Issues.** Open an issue if you find a typo, hit a bug, or have a question.
+- **Pull requests.** New collections, implementation improvements, tests, documentation, and typo fixes are welcome.
 
 ## License
 
-Licensed under MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+Licensed under the MIT license ([LICENSE](LICENSE) or http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ assert_eq!(results[0].id, 1);
 assert!(results[0].score > 0.0);
 ```
 
+Search returns up to 10 results by default. It supports last-token prefix
+matching and typo tolerance by default, which fits search boxes and autocomplete
+suggestions.
+
 Also try the interactive demo by:
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ assert_eq!(results[0].id, 1);
 assert!(results[0].score > 0.0);
 ```
 
-Search returns up to 10 results by default. It supports last-token prefix
-matching and typo tolerance by default, which fits search boxes and autocomplete
-suggestions.
-
 Also try the interactive demo by:
 
 ```

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 
-use simsearch::{SearchOptions, SimSearch};
+use simsearch::Index;
 
 fn load_books() -> Vec<String> {
     let mut file = File::open("./books.json").unwrap();
@@ -17,7 +17,7 @@ fn add_books(bencher: divan::Bencher) {
     let books = load_books();
 
     bencher.bench(|| {
-        let mut engine = SimSearch::new();
+        let mut engine = Index::new();
 
         for title in &books {
             engine.insert(title, title);
@@ -30,20 +30,7 @@ fn add_books(bencher: divan::Bencher) {
 #[divan::bench]
 fn search_jaro_winkler(bencher: divan::Bencher) {
     let books = load_books();
-    let mut engine = SimSearch::new();
-
-    for title in &books {
-        engine.insert(title, title);
-    }
-
-    bencher.bench(|| engine.search("odl sea"));
-}
-
-#[divan::bench]
-fn search_levenshtein(bencher: divan::Bencher) {
-    let books = load_books();
-    let options = SearchOptions::new().levenshtein(true);
-    let mut engine = SimSearch::new_with(options);
+    let mut engine = Index::new();
 
     for title in &books {
         engine.insert(title, title);

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -28,7 +28,7 @@ fn add_books(bencher: divan::Bencher) {
 }
 
 #[divan::bench]
-fn search_jaro_winkler(bencher: divan::Bencher) {
+fn search_typo_tolerant(bencher: divan::Bencher) {
     let books = load_books();
     let mut engine = Index::new();
 

--- a/examples/books.rs
+++ b/examples/books.rs
@@ -2,11 +2,11 @@ use std::fs::File;
 
 use inquire::ui::{Color, RenderConfig, StyleSheet, Styled};
 use inquire::{
-    autocompletion::{Autocomplete, Replacement},
     CustomUserError, Text,
+    autocompletion::{Autocomplete, Replacement},
 };
 
-use simsearch::SimSearch;
+use simsearch::Index;
 
 fn main() {
     inquire::set_global_render_config(get_render_config());
@@ -14,14 +14,14 @@ fn main() {
     Text::new("Search for a book:")
         .with_autocomplete(BookSearcher::load())
         .with_help_message("Try typing 'old man'")
-        .with_page_size(15)
+        .with_page_size(10)
         .prompt()
         .ok();
 }
 
 #[derive(Clone)]
 pub struct BookSearcher {
-    engine: SimSearch<String>,
+    engine: Index<String>,
 }
 
 impl BookSearcher {
@@ -34,7 +34,7 @@ impl BookSearcher {
             .iter()
             .map(|v| v.as_str().unwrap().to_string())
             .collect::<Vec<_>>();
-        let mut engine = SimSearch::new();
+        let mut engine = Index::new();
 
         for title in books {
             engine.insert(title.clone(), &title);
@@ -46,15 +46,24 @@ impl BookSearcher {
 
 impl Autocomplete for BookSearcher {
     fn get_suggestions(&mut self, input: &str) -> Result<Vec<String>, CustomUserError> {
-        Ok(self.engine.search(input))
+        Ok(self
+            .engine
+            .search(input)
+            .into_iter()
+            .map(|hit| format!("{:.3}  {}", hit.score, hit.id))
+            .collect())
     }
 
     fn get_completion(
         &mut self,
         _: &str,
-        _: Option<String>,
+        suggestion: Option<String>,
     ) -> Result<Replacement, CustomUserError> {
-        Ok(None)
+        Ok(suggestion.and_then(|suggestion| {
+            suggestion
+                .split_once("  ")
+                .map(|(_, title)| title.to_string())
+        }))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,12 @@ use std::hash::Hash;
 
 use strsim::jaro_winkler;
 
-const QUALITY_WEIGHT: f64 = 0.70;
-const COVERAGE_WEIGHT: f64 = 0.15;
-const PROXIMITY_WEIGHT: f64 = 0.08;
+const QUALITY_WEIGHT: f64 = 0.68;
+const COVERAGE_WEIGHT: f64 = 0.14;
+const PROXIMITY_WEIGHT: f64 = 0.07;
 const EXACTNESS_WEIGHT: f64 = 0.04;
 const POSITION_WEIGHT: f64 = 0.03;
+const SPECIFICITY_WEIGHT: f64 = 0.04;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -116,11 +117,13 @@ impl Rank {
         };
         let exactness = exact_terms as f64 / query_len as f64;
         let position_score = Self::position_score(first_position, doc_len);
+        let specificity = matched_terms as f64 / doc_len as f64;
         let weighted_bonus = QUALITY_WEIGHT
             + COVERAGE_WEIGHT * coverage
             + PROXIMITY_WEIGHT * proximity_score
             + EXACTNESS_WEIGHT * exactness
-            + POSITION_WEIGHT * position_score;
+            + POSITION_WEIGHT * position_score
+            + SPECIFICITY_WEIGHT * specificity;
         let score = quality * weighted_bonus;
 
         Rank {
@@ -357,9 +360,8 @@ where
             return None;
         }
 
-        let mut matches_by_query = Vec::with_capacity(pattern_tokens.len());
+        let mut matches = Vec::new();
         for (query_index, pattern_token) in pattern_tokens.iter().enumerate() {
-            let mut matches = Vec::new();
             for (doc_index, token) in tokens.iter().enumerate() {
                 if let Some(similarity) = self.token_similarity(pattern_token, token) {
                     matches.push(TokenMatch {
@@ -371,27 +373,17 @@ where
                     });
                 }
             }
-            matches.sort_by(Self::compare_token_matches);
-            matches_by_query.push(matches);
         }
+        matches.sort_by(Self::compare_token_matches);
 
-        let mut query_order: Vec<usize> = (0..pattern_tokens.len()).collect();
-        query_order.sort_by(|lhs, rhs| {
-            matches_by_query[*lhs]
-                .len()
-                .cmp(&matches_by_query[*rhs].len())
-                .then_with(|| lhs.cmp(rhs))
-        });
-
+        let mut used_queries = vec![false; pattern_tokens.len()];
         let mut used_tokens = vec![false; tokens.len()];
         let mut selected = Vec::new();
-        for query_index in query_order {
-            for token_match in &matches_by_query[query_index] {
-                if !used_tokens[token_match.doc_index] {
-                    used_tokens[token_match.doc_index] = true;
-                    selected.push(token_match.clone());
-                    break;
-                }
+        for token_match in matches {
+            if !used_queries[token_match.query_index] && !used_tokens[token_match.doc_index] {
+                used_queries[token_match.query_index] = true;
+                used_tokens[token_match.doc_index] = true;
+                selected.push(token_match);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ const PROXIMITY_WEIGHT: f64 = 0.07;
 const EXACTNESS_WEIGHT: f64 = 0.04;
 const POSITION_WEIGHT: f64 = 0.03;
 const SPECIFICITY_WEIGHT: f64 = 0.04;
-const ASSIGNMENT_BEAM_WIDTH: usize = 64;
 
 type PostingMap = HashMap<usize, Vec<usize>>;
 
@@ -101,8 +100,57 @@ struct TermCandidate {
 #[derive(Debug, Clone)]
 struct AssignmentState {
     selected: Vec<TokenMatch>,
-    used_tokens: Vec<bool>,
-    rank: Rank,
+    metrics: AssignmentMetrics,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AssignmentMetrics {
+    matched_terms: usize,
+    score_sum: f64,
+    exact_terms: usize,
+    proximity_cost: usize,
+    first_position: usize,
+    last_position: Option<usize>,
+}
+
+impl AssignmentState {
+    fn new() -> Self {
+        AssignmentState {
+            selected: Vec::new(),
+            metrics: AssignmentMetrics {
+                matched_terms: 0,
+                score_sum: 0.0,
+                exact_terms: 0,
+                proximity_cost: 0,
+                first_position: usize::MAX,
+                last_position: None,
+            },
+        }
+    }
+
+    fn with_match(&self, token_match: TokenMatch) -> Self {
+        let mut selected = self.selected.clone();
+        selected.push(token_match.clone());
+
+        let proximity_cost = self.metrics.proximity_cost
+            + self
+                .metrics
+                .last_position
+                .map(|last_position| token_match.doc_index - last_position - 1)
+                .unwrap_or(0);
+
+        AssignmentState {
+            selected,
+            metrics: AssignmentMetrics {
+                matched_terms: self.metrics.matched_terms + 1,
+                score_sum: self.metrics.score_sum + token_match.score,
+                exact_terms: self.metrics.exact_terms + usize::from(token_match.exact),
+                proximity_cost,
+                first_position: self.metrics.first_position.min(token_match.doc_index),
+                last_position: Some(token_match.doc_index),
+            },
+        }
+    }
 }
 
 impl Rank {
@@ -414,7 +462,7 @@ where
             matches.sort_by(Self::compare_token_matches);
         }
 
-        let mut selected = Self::select_best_matches(&matches_by_query, tokens.len());
+        let mut selected = Self::select_best_matches(&matches_by_query);
         if selected.is_empty() {
             return None;
         }
@@ -428,59 +476,30 @@ where
         ))
     }
 
-    fn select_best_matches(
-        matches_by_query: &[Vec<TokenMatch>],
-        doc_len: usize,
-    ) -> Vec<TokenMatch> {
-        let query_len = matches_by_query.len();
-        let mut query_order: Vec<usize> = (0..query_len).collect();
-        query_order.sort_by(|lhs, rhs| {
-            matches_by_query[*lhs]
-                .len()
-                .cmp(&matches_by_query[*rhs].len())
-                .then_with(|| lhs.cmp(rhs))
-        });
+    fn select_best_matches(matches_by_query: &[Vec<TokenMatch>]) -> Vec<TokenMatch> {
+        let mut states = vec![AssignmentState::new()];
 
-        let mut states = vec![AssignmentState {
-            selected: Vec::new(),
-            used_tokens: vec![false; doc_len],
-            rank: Rank { score: 0.0 },
-        }];
-
-        for query_index in query_order {
-            let matches = &matches_by_query[query_index];
+        for matches in matches_by_query {
             if matches.is_empty() {
                 continue;
             }
 
-            let mut next_states = Vec::new();
+            let mut next_states = states.clone();
             for state in &states {
-                next_states.push(state.clone());
-
                 for token_match in matches {
-                    if state.used_tokens[token_match.doc_index] {
+                    if state
+                        .metrics
+                        .last_position
+                        .is_some_and(|last_position| token_match.doc_index <= last_position)
+                    {
                         continue;
                     }
 
-                    let mut selected = state.selected.clone();
-                    selected.push(token_match.clone());
-                    selected.sort_by_key(|selected_match| selected_match.query_index);
-
-                    let mut used_tokens = state.used_tokens.clone();
-                    used_tokens[token_match.doc_index] = true;
-                    let rank = Rank::from_matches(&selected, query_len, doc_len);
-
-                    next_states.push(AssignmentState {
-                        selected,
-                        used_tokens,
-                        rank,
-                    });
+                    next_states.push(state.with_match(token_match.clone()));
                 }
             }
 
-            next_states.sort_by(Self::compare_assignment_states);
-            next_states.truncate(ASSIGNMENT_BEAM_WIDTH);
-            states = next_states;
+            states = Self::prune_assignment_states(next_states);
         }
 
         states.sort_by(Self::compare_assignment_states);
@@ -491,25 +510,62 @@ where
             .unwrap_or_default()
     }
 
+    fn prune_assignment_states(states: Vec<AssignmentState>) -> Vec<AssignmentState> {
+        let mut best_by_last_position: HashMap<Option<usize>, AssignmentState> = HashMap::new();
+
+        for state in states {
+            let last_position = state.metrics.last_position;
+            if let Some(current) = best_by_last_position.get_mut(&last_position) {
+                if Self::compare_assignment_states(&state, current).is_lt() {
+                    *current = state;
+                }
+            } else {
+                best_by_last_position.insert(last_position, state);
+            }
+        }
+
+        let mut states: Vec<AssignmentState> = best_by_last_position.into_values().collect();
+        states.sort_by(Self::compare_assignment_states);
+        states
+    }
+
     fn compare_assignment_states(lhs: &AssignmentState, rhs: &AssignmentState) -> Ordering {
-        rhs.rank
-            .score
-            .partial_cmp(&lhs.rank.score)
-            .unwrap_or(Ordering::Equal)
-            .then_with(|| rhs.selected.len().cmp(&lhs.selected.len()))
+        rhs.metrics
+            .matched_terms
+            .cmp(&lhs.metrics.matched_terms)
             .then_with(|| {
-                let lhs_score = lhs
-                    .selected
-                    .iter()
-                    .map(|token_match| token_match.score)
-                    .sum::<f64>();
-                let rhs_score = rhs
-                    .selected
-                    .iter()
-                    .map(|token_match| token_match.score)
-                    .sum::<f64>();
-                rhs_score.partial_cmp(&lhs_score).unwrap_or(Ordering::Equal)
+                rhs.metrics
+                    .score_sum
+                    .partial_cmp(&lhs.metrics.score_sum)
+                    .unwrap_or(Ordering::Equal)
             })
+            .then_with(|| rhs.metrics.exact_terms.cmp(&lhs.metrics.exact_terms))
+            .then_with(|| lhs.metrics.proximity_cost.cmp(&rhs.metrics.proximity_cost))
+            .then_with(|| lhs.metrics.first_position.cmp(&rhs.metrics.first_position))
+            .then_with(|| lhs.metrics.last_position.cmp(&rhs.metrics.last_position))
+            .then_with(|| Self::compare_selected_matches(&lhs.selected, &rhs.selected))
+    }
+
+    fn compare_selected_matches(lhs: &[TokenMatch], rhs: &[TokenMatch]) -> Ordering {
+        for (lhs_match, rhs_match) in lhs.iter().zip(rhs) {
+            let ordering = lhs_match
+                .query_index
+                .cmp(&rhs_match.query_index)
+                .then_with(|| lhs_match.doc_index.cmp(&rhs_match.doc_index))
+                .then_with(|| {
+                    rhs_match
+                        .score
+                        .partial_cmp(&lhs_match.score)
+                        .unwrap_or(Ordering::Equal)
+                })
+                .then_with(|| rhs_match.exact.cmp(&lhs_match.exact));
+
+            if !ordering.is_eq() {
+                return ordering;
+            }
+        }
+
+        lhs.len().cmp(&rhs.len())
     }
 
     fn compare_ranked_results(&self, lhs: &RankedResult<Id>, rhs: &RankedResult<Id>) -> Ordering {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ const PROXIMITY_WEIGHT: f64 = 0.07;
 const EXACTNESS_WEIGHT: f64 = 0.04;
 const POSITION_WEIGHT: f64 = 0.03;
 const SPECIFICITY_WEIGHT: f64 = 0.04;
-const MAX_ASSIGNMENT_STATES: usize = 64;
+const ASSIGNMENT_BEAM_WIDTH: usize = 64;
 
 type PostingMap = HashMap<usize, Vec<usize>>;
 
@@ -479,7 +479,7 @@ where
             }
 
             next_states.sort_by(Self::compare_assignment_states);
-            next_states.truncate(MAX_ASSIGNMENT_STATES);
+            next_states.truncate(ASSIGNMENT_BEAM_WIDTH);
             states = next_states;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 
+use strsim::jaro_winkler;
+
 const QUALITY_WEIGHT: f64 = 0.68;
 const COVERAGE_WEIGHT: f64 = 0.14;
 const PROXIMITY_WEIGHT: f64 = 0.07;
@@ -48,7 +50,6 @@ where
     forward_map: HashMap<usize, Vec<String>>,
     reverse_map: HashMap<String, PostingMap>,
     terms: BTreeSet<String>,
-    typo_map: HashMap<String, HashSet<String>>,
 }
 
 /// A search result with its normalized relevance score.
@@ -82,14 +83,12 @@ struct TokenMatch {
     query_index: usize,
     doc_index: usize,
     score: f64,
-    typo_cost: usize,
     exact: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct TokenSimilarity {
     score: f64,
-    typo_cost: usize,
     exact: bool,
 }
 
@@ -206,7 +205,6 @@ where
             forward_map: HashMap::new(),
             reverse_map: HashMap::new(),
             terms: BTreeSet::new(),
-            typo_map: HashMap::new(),
         }
     }
 
@@ -383,7 +381,6 @@ where
                                 query_index,
                                 doc_index: *doc_index,
                                 score: candidate.similarity.score,
-                                typo_cost: candidate.similarity.typo_cost,
                                 exact: candidate.similarity.exact,
                             });
                         }
@@ -525,7 +522,6 @@ where
         rhs.score
             .partial_cmp(&lhs.score)
             .unwrap_or(Ordering::Equal)
-            .then_with(|| lhs.typo_cost.cmp(&rhs.typo_cost))
             .then_with(|| rhs.exact.cmp(&lhs.exact))
             .then_with(|| lhs.doc_index.cmp(&rhs.doc_index))
             .then_with(|| lhs.query_index.cmp(&rhs.query_index))
@@ -540,7 +536,6 @@ where
                 pattern_token,
                 TokenSimilarity {
                     score: 1.0,
-                    typo_cost: 0,
                     exact: true,
                 },
             );
@@ -557,7 +552,6 @@ where
                     term,
                     TokenSimilarity {
                         score: Self::prefix_score(pattern_token, term),
-                        typo_cost: 0,
                         exact: false,
                     },
                 );
@@ -565,27 +559,26 @@ where
         }
 
         if self.options.typo_tolerance {
-            for term in self.typo_terms(pattern_token) {
+            for term in &self.terms {
+                let term = term.as_str();
                 if term == pattern_token {
                     continue;
                 }
 
-                let max_typos = Self::allowed_typos(pattern_token);
-                if let Some(typo_cost) = Self::edit_distance_at_most(pattern_token, term, max_typos)
-                {
+                let score = Self::typo_score(
+                    pattern_token,
+                    term,
+                    self.options.prefix_search && prefix_search,
+                );
+                if score >= Self::min_typo_score(pattern_token) {
                     Self::insert_candidate(
                         &mut candidates,
                         term,
                         TokenSimilarity {
-                            score: Self::typo_score(pattern_token, term, typo_cost),
-                            typo_cost,
+                            score,
                             exact: false,
                         },
                     );
-                } else if self.options.prefix_search && prefix_search {
-                    if let Some(similarity) = Self::prefix_typo_similarity(pattern_token, term) {
-                        Self::insert_candidate(&mut candidates, term, similarity);
-                    }
                 }
             }
         }
@@ -615,7 +608,6 @@ where
         rhs.score
             .partial_cmp(&lhs.score)
             .unwrap_or(Ordering::Equal)
-            .then_with(|| lhs.typo_cost.cmp(&rhs.typo_cost))
             .then_with(|| rhs.exact.cmp(&lhs.exact))
     }
 
@@ -631,151 +623,55 @@ where
             .collect()
     }
 
-    fn typo_terms(&self, pattern_token: &str) -> Vec<&str> {
-        let mut terms = HashSet::new();
-        for variant in Self::deletion_variants(pattern_token, Self::allowed_typos(pattern_token)) {
-            if let Some(candidates) = self.typo_map.get(&variant) {
-                for term in candidates {
-                    terms.insert(term.as_str());
-                }
-            }
-        }
-
-        terms.into_iter().collect()
-    }
-
     fn prefix_score(prefix: &str, term: &str) -> f64 {
         let prefix_len = prefix.chars().count();
         let term_len = term.chars().count().max(1);
         0.9 + 0.1 * prefix_len as f64 / term_len as f64
     }
 
-    fn typo_score(pattern_token: &str, term: &str, typo_cost: usize) -> f64 {
-        let len = pattern_token
-            .chars()
-            .count()
-            .max(term.chars().count())
-            .max(1);
-        1.0 - typo_cost as f64 / (len + 1) as f64
+    fn typo_score(pattern_token: &str, term: &str, prefix_search: bool) -> f64 {
+        let mut score = jaro_winkler(pattern_token, term);
+
+        if prefix_search {
+            score = score.max(Self::prefix_typo_score(pattern_token, term));
+        }
+
+        score
     }
 
-    fn prefix_typo_similarity(pattern_token: &str, term: &str) -> Option<TokenSimilarity> {
-        let max_typos = Self::allowed_typos(pattern_token);
-        let prefix_len = pattern_token.chars().count() + max_typos;
-        let term_prefix: String = term.chars().take(prefix_len).collect();
-        let typo_cost = Self::edit_distance_at_most(pattern_token, &term_prefix, max_typos)?;
-        let score = Self::typo_score(pattern_token, &term_prefix, typo_cost)
-            .min(Self::prefix_score(pattern_token, term));
+    fn prefix_typo_score(pattern_token: &str, term: &str) -> f64 {
+        let pattern_len = pattern_token.chars().count();
+        if pattern_len == 0 {
+            return 0.0;
+        }
 
-        Some(TokenSimilarity {
-            score,
-            typo_cost,
-            exact: false,
-        })
+        let term_len = term.chars().count();
+        let min_len = pattern_len.saturating_sub(1).max(1);
+        let max_len = (pattern_len + 2).min(term_len);
+        let mut score: f64 = 0.0;
+
+        for len in min_len..=max_len {
+            let prefix: String = term.chars().take(len).collect();
+            score = score.max(jaro_winkler(pattern_token, &prefix));
+        }
+
+        score.min(Self::prefix_score(pattern_token, term))
     }
 
-    fn allowed_typos(token: &str) -> usize {
-        match token.chars().count() {
-            0..=2 => 0,
-            3..=5 => 1,
-            _ => 2,
+    fn min_typo_score(pattern_token: &str) -> f64 {
+        match pattern_token.chars().count() {
+            0..=3 => 0.6,
+            4..=5 => 0.7,
+            _ => 0.75,
         }
     }
 
     fn add_term(&mut self, term: &str) {
         self.terms.insert(term.to_string());
-        for variant in Self::deletion_variants(term, Self::allowed_typos(term)) {
-            self.typo_map
-                .entry(variant)
-                .or_default()
-                .insert(term.to_string());
-        }
     }
 
     fn remove_term(&mut self, term: &str) {
         self.terms.remove(term);
-        for variant in Self::deletion_variants(term, Self::allowed_typos(term)) {
-            if let Some(terms) = self.typo_map.get_mut(&variant) {
-                terms.remove(term);
-                if terms.is_empty() {
-                    self.typo_map.remove(&variant);
-                }
-            }
-        }
-    }
-
-    fn deletion_variants(token: &str, max_deletions: usize) -> HashSet<String> {
-        let mut variants = HashSet::from([token.to_string()]);
-        let mut current = HashSet::from([token.to_string()]);
-
-        for _ in 0..max_deletions {
-            let mut next = HashSet::new();
-            for variant in &current {
-                let chars: Vec<char> = variant.chars().collect();
-                for index in 0..chars.len() {
-                    let mut deleted = String::with_capacity(variant.len());
-                    for (char_index, character) in chars.iter().enumerate() {
-                        if char_index != index {
-                            deleted.push(*character);
-                        }
-                    }
-                    if variants.insert(deleted.clone()) {
-                        next.insert(deleted);
-                    }
-                }
-            }
-            current = next;
-        }
-
-        variants
-    }
-
-    fn edit_distance_at_most(lhs: &str, rhs: &str, max_distance: usize) -> Option<usize> {
-        let lhs: Vec<char> = lhs.chars().collect();
-        let rhs: Vec<char> = rhs.chars().collect();
-
-        if lhs.len().abs_diff(rhs.len()) > max_distance {
-            return None;
-        }
-
-        let mut distances = vec![vec![0; rhs.len() + 1]; lhs.len() + 1];
-        for (lhs_index, row) in distances.iter_mut().enumerate() {
-            row[0] = lhs_index;
-        }
-        for (rhs_index, distance) in distances[0].iter_mut().enumerate() {
-            *distance = rhs_index;
-        }
-
-        for (lhs_index, lhs_char) in lhs.iter().enumerate() {
-            let row = lhs_index + 1;
-            let mut row_min = distances[row][0];
-
-            for (rhs_index, rhs_char) in rhs.iter().enumerate() {
-                let column = rhs_index + 1;
-                let substitution_cost = usize::from(lhs_char != rhs_char);
-                distances[row][column] = (distances[row - 1][column] + 1)
-                    .min(distances[row][column - 1] + 1)
-                    .min(distances[row - 1][column - 1] + substitution_cost);
-
-                if row > 1
-                    && column > 1
-                    && lhs[row - 1] == rhs[column - 2]
-                    && lhs[row - 2] == rhs[column - 1]
-                {
-                    distances[row][column] =
-                        distances[row][column].min(distances[row - 2][column - 2] + 1);
-                }
-
-                row_min = row_min.min(distances[row][column]);
-            }
-
-            if row_min > max_distance {
-                return None;
-            }
-        }
-
-        let distance = distances[lhs.len()][rhs.len()];
-        (distance <= max_distance).then_some(distance)
     }
 
     /// Removes an entry by ID.
@@ -806,7 +702,6 @@ where
         self.forward_map.clear();
         self.reverse_map.clear();
         self.terms.clear();
-        self.typo_map.clear();
     }
 
     fn tokenize(&self, tokens: &[&str]) -> Vec<String> {
@@ -904,7 +799,7 @@ impl Options {
         }
     }
 
-    /// Sets whether search tolerates typos using bounded edit distance.
+    /// Sets whether search tolerates typos using Jaro-Winkler similarity.
     ///
     /// Defaults to `true`.
     pub fn typo_tolerance(self, typo_tolerance: bool) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,51 +1,45 @@
-//! A simple and lightweight fuzzy search engine that works in memory, searching for
-//! similar strings (a pun here).
+//! A small in-memory fuzzy search index for embedded autocomplete and search
+//! suggestions.
 //!
 //! # Examples
 //!
 //! ```
-//! use simsearch::SimSearch;
+//! use simsearch::Index;
 //!
-//! let mut engine: SimSearch<u32> = SimSearch::new();
+//! let mut engine: Index<u32> = Index::new();
 //!
 //! engine.insert(1, "Things Fall Apart");
 //! engine.insert(2, "The Old Man and the Sea");
 //! engine.insert(3, "James Joyce");
 //!
-//! let results: Vec<u32> = engine.search("thngs");
+//! let results = engine.search("thngs");
 //!
-//! assert_eq!(results, &[1]);
-//! ```
-//!
-//! By default, Jaro-Winkler distance is used. An alternative Levenshtein distance, which is
-//! SIMD-accelerated but only works for ASCII byte strings, can be specified with `SearchOptions`:
-//!
-//! ```
-//! use simsearch::{SimSearch, SearchOptions};
-//!
-//! let options = SearchOptions::new().levenshtein(true);
-//! let mut engine: SimSearch<u32> = SimSearch::new_with(options);
+//! assert_eq!(results[0].id, 1);
 //! ```
 
-use std::cmp::{max, Ordering};
-use std::collections::HashMap;
-use std::f64;
+use std::cmp::{Ordering, max};
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
 use strsim::jaro_winkler;
-use triple_accel::levenshtein::levenshtein_simd_k;
+
+const QUALITY_WEIGHT: f64 = 0.70;
+const COVERAGE_WEIGHT: f64 = 0.15;
+const PROXIMITY_WEIGHT: f64 = 0.08;
+const EXACTNESS_WEIGHT: f64 = 0.04;
+const POSITION_WEIGHT: f64 = 0.03;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// The simple search engine.
+/// An in-memory fuzzy search index.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct SimSearch<Id>
+pub struct Index<Id>
 where
-    Id: Eq + PartialEq + Clone + Hash + Ord,
+    Id: Eq + Clone + Hash,
 {
-    option: SearchOptions,
+    options: Options,
     id_num_counter: usize,
     ids_map: HashMap<Id, usize>,
     reverse_ids_map: HashMap<usize, Id>,
@@ -53,28 +47,140 @@ where
     reverse_map: HashMap<String, Vec<usize>>,
 }
 
-impl<Id> SimSearch<Id>
-where
-    Id: Eq + PartialEq + Clone + Hash + Ord,
-{
-    /// Creates search engine with default options.
-    pub fn new() -> Self {
-        Self::new_with(SearchOptions::new())
+/// A search result with its normalized relevance score.
+///
+/// Scores range from `0.0` to `1.0` and are meaningful for comparing results
+/// from the same search query. Results are sorted by this score, with insertion
+/// order used as the final tie-breaker.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Hit<Id> {
+    /// The id associated with the matched entry.
+    pub id: Id,
+    /// A normalized relevance score in the `0.0..=1.0` range.
+    pub score: f64,
+}
+
+#[derive(Debug, Clone)]
+struct RankedResult<Id> {
+    id_num: usize,
+    id: Id,
+    rank: Rank,
+}
+
+#[derive(Debug, Clone)]
+struct Rank {
+    score: f64,
+}
+
+#[derive(Debug, Clone)]
+struct TokenMatch {
+    query_index: usize,
+    doc_index: usize,
+    score: f64,
+    typo_cost: usize,
+    exact: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TokenSimilarity {
+    score: f64,
+    typo_cost: usize,
+    exact: bool,
+}
+
+impl Rank {
+    fn from_matches(matches: &[TokenMatch], query_len: usize, doc_len: usize) -> Self {
+        let matched_terms = matches.len();
+        let proximity_cost = Self::proximity_cost(matches, doc_len);
+        let first_position = matches
+            .iter()
+            .map(|token_match| token_match.doc_index)
+            .min()
+            .unwrap_or(usize::MAX);
+        let exact_terms = matches
+            .iter()
+            .filter(|token_match| token_match.exact)
+            .count();
+        let quality = matches
+            .iter()
+            .map(|token_match| token_match.score)
+            .sum::<f64>()
+            / query_len as f64;
+
+        let coverage = matched_terms as f64 / query_len as f64;
+        let proximity_score = if matched_terms < 2 {
+            coverage
+        } else {
+            1.0 / (1.0 + proximity_cost as f64 / (matched_terms - 1) as f64)
+        };
+        let exactness = exact_terms as f64 / query_len as f64;
+        let position_score = Self::position_score(first_position, doc_len);
+        let weighted_bonus = QUALITY_WEIGHT
+            + COVERAGE_WEIGHT * coverage
+            + PROXIMITY_WEIGHT * proximity_score
+            + EXACTNESS_WEIGHT * exactness
+            + POSITION_WEIGHT * position_score;
+        let score = quality * weighted_bonus;
+
+        Rank {
+            score: score.clamp(0.0, 1.0),
+        }
     }
 
-    /// Creates search engine with custom options.
+    fn proximity_cost(matches: &[TokenMatch], doc_len: usize) -> usize {
+        if matches.len() < 2 {
+            return 0;
+        }
+
+        let mut cost = 0;
+        for window in matches.windows(2) {
+            let lhs = window[0].doc_index;
+            let rhs = window[1].doc_index;
+            if rhs > lhs {
+                cost += rhs - lhs - 1;
+            } else {
+                cost += doc_len + lhs - rhs + 1;
+            }
+        }
+        cost
+    }
+
+    fn position_score(first_position: usize, doc_len: usize) -> f64 {
+        if first_position >= doc_len {
+            return 0.0;
+        }
+
+        if doc_len <= 1 {
+            return 1.0;
+        }
+
+        1.0 - first_position as f64 / (doc_len - 1) as f64
+    }
+}
+
+impl<Id> Index<Id>
+where
+    Id: Eq + Clone + Hash,
+{
+    /// Creates an index with default options.
+    pub fn new() -> Self {
+        Self::with_options(Options::new())
+    }
+
+    /// Creates an index with custom options.
     ///
     /// # Examples
     ///
     /// ```
-    /// use simsearch::{SearchOptions, SimSearch};
+    /// use simsearch::{Options, Index};
     ///
-    /// let mut engine: SimSearch<usize> = SimSearch::new_with(
-    ///     SearchOptions::new().case_sensitive(true));
+    /// let mut engine: Index<usize> = Index::with_options(
+    ///     Options::new().case_sensitive(true));
     /// ```
-    pub fn new_with(option: SearchOptions) -> Self {
-        SimSearch {
-            option,
+    pub fn with_options(options: Options) -> Self {
+        Index {
+            options,
             id_num_counter: 0,
             ids_map: HashMap::new(),
             reverse_ids_map: HashMap::new(),
@@ -83,27 +189,24 @@ where
         }
     }
 
-    /// Inserts an entry into search engine.
+    /// Inserts an entry into the index.
     ///
     /// Input will be tokenized according to the search option.
-    /// By default whitespaces(including tabs) are considered as stop words,
-    /// you can change the behavior by providing `SearchOptions`.
+    /// By default whitespaces(including tabs) are considered as separators,
+    /// you can change the behavior by providing `Options`.
     ///
     /// Insert with an existing id updates the content.
     ///
     /// **Note that** id is not searchable. Add id to the contents if you would
     /// like to perform search on it.
     ///
-    /// Additionally, note that content must be an ASCII string if Levenshtein
-    /// distance is used.
-    ///
     /// # Examples
     ///
     /// ```
-    /// use simsearch::{SearchOptions, SimSearch};
+    /// use simsearch::{Options, Index};
     ///
-    /// let mut engine: SimSearch<&str> = SimSearch::new_with(
-    ///     SearchOptions::new().stop_words(vec![",".to_string(), ".".to_string()]));
+    /// let mut engine: Index<&str> = Index::with_options(
+    ///     Options::new().separators(vec![",".to_string(), ".".to_string()]));
     ///
     /// engine.insert("BoJack Horseman", "BoJack Horseman, an American
     /// adult animated comedy-drama series created by Raphael Bob-Waksberg.
@@ -112,42 +215,59 @@ where
     /// Alison Brie, Paul F. Tompkins, and Aaron Paul.");
     /// ```
     pub fn insert(&mut self, id: Id, content: &str) {
-        self.insert_tokens(id, &[content])
+        let tokens = self.tokenize(&[content]);
+        self.insert_normalized_tokens(id, tokens)
     }
 
-    /// Inserts entry tokens into search engine.
+    /// Inserts an entry with multiple searchable fields into the index.
     ///
-    /// Search engine also applies tokenizer to the
-    /// provided tokens. Use this method when you have
-    /// special tokenization rules in addition to the built-in ones.
+    /// Each field is tokenized with the same built-in tokenizer used by
+    /// [`Index::insert`]. This is useful when an item has several searchable
+    /// fields, such as a title, author, tags, or aliases.
     ///
     /// Insert with an existing id updates the content.
     ///
     /// **Note that** id is not searchable. Add id to the contents if you would
     /// like to perform search on it.
     ///
-    /// Additionally, note that each token must be an ASCII string if Levenshtein
-    /// distance is used.
-    ///
     /// # Examples
     ///
     /// ```
-    /// use simsearch::SimSearch;
+    /// use simsearch::Index;
     ///
-    /// let mut engine: SimSearch<&str> = SimSearch::new();
+    /// let mut engine: Index<&str> = Index::new();
     ///
-    /// engine.insert_tokens("Arya Stark", &["Arya Stark", "a fictional
-    /// character in American author George R. R", "portrayed by English actress."]);
-    pub fn insert_tokens(&mut self, id: Id, tokens: &[&str]) {
+    /// engine.insert_many("A Game of Thrones", [
+    ///     "A Game of Thrones",
+    ///     "George R. R. Martin",
+    ///     "fantasy",
+    /// ]);
+    ///
+    /// let results = engine.search("martin");
+    ///
+    /// assert_eq!(results[0].id, "A Game of Thrones");
+    /// ```
+    pub fn insert_many<I, S>(&mut self, id: Id, fields: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let fields: Vec<String> = fields
+            .into_iter()
+            .map(|field| field.as_ref().to_string())
+            .collect();
+        let fields: Vec<&str> = fields.iter().map(String::as_str).collect();
+        let tokens = self.tokenize(&fields);
+        self.insert_normalized_tokens(id, tokens)
+    }
+
+    fn insert_normalized_tokens(&mut self, id: Id, tokens: Vec<String>) {
         self.remove(&id);
 
         let id_num = self.id_num_counter;
         self.ids_map.insert(id.clone(), id_num);
         self.reverse_ids_map.insert(id_num, id);
         self.id_num_counter += 1;
-
-        let mut tokens = self.tokenize(tokens);
-        tokens.sort();
 
         for token in tokens.clone() {
             self.reverse_map
@@ -159,170 +279,49 @@ where
         self.forward_map.insert(id_num, tokens);
     }
 
-    /// Searches pattern and returns ids sorted by relevance.
+    /// Searches pattern and returns hits sorted by relevance.
     ///
     /// Pattern will be tokenized according to the search option.
-    /// By default whitespaces(including tabs) are considered as stop words,
-    /// you can change the behavior by providing `SearchOptions`.
-    ///
-    /// Additionally, note that pattern must be an ASCII string if Levenshtein
-    /// distance is used.
+    /// By default whitespaces(including tabs) are considered as separators,
+    /// you can change the behavior by providing `Options`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use simsearch::SimSearch;
+    /// use simsearch::Index;
     ///
-    /// let mut engine: SimSearch<u32> = SimSearch::new();
+    /// let mut engine: Index<u32> = Index::new();
     ///
     /// engine.insert(1, "Things Fall Apart");
     /// engine.insert(2, "The Old Man and the Sea");
     /// engine.insert(3, "James Joyce");
     ///
-    /// let results: Vec<u32> = engine.search("thngs apa");
+    /// let results = engine.search("thngs apa");
     ///
-    /// assert_eq!(results, &[1]);
-    pub fn search(&self, pattern: &str) -> Vec<Id> {
-        self.search_with_scores(pattern)
+    /// assert_eq!(results[0].id, 1);
+    /// assert!(results[0].score > 0.0);
+    /// ```
+    pub fn search(&self, pattern: &str) -> Vec<Hit<Id>> {
+        self.search_ranked(self.tokenize(&[pattern]))
             .into_iter()
-            .map(|(id, _score)| id)
+            .map(|result| Hit {
+                id: result.id,
+                score: result.rank.score,
+            })
             .collect()
     }
 
-    /// Searches pattern and returns ids with scores sorted by relevance.
-    ///
-    /// Pattern will be tokenized according to the search option.
-    /// By default whitespaces(including tabs) are considered as stop words,
-    /// you can change the behavior by providing `SearchOptions`.
-    ///
-    /// Additionally, note that pattern must be an ASCII string if Levenshtein
-    /// distance is used.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use simsearch::SimSearch;
-    ///
-    /// let mut engine: SimSearch<u32> = SimSearch::new();
-    ///
-    /// engine.insert(1, "Things Fall Apart");
-    ///
-    /// let results: Vec<(u32, f64)> = engine.search_with_scores("thngs");
-    ///
-    /// assert_eq!(results[0].0, 1);
-    /// ```
-    pub fn search_with_scores(&self, pattern: &str) -> Vec<(Id, f64)> {
-        self.search_tokens_with_scores(&[pattern])
-    }
+    fn search_ranked(&self, pattern_tokens: Vec<String>) -> Vec<RankedResult<Id>> {
+        if pattern_tokens.is_empty() || self.options.limit == 0 {
+            return Vec::new();
+        }
 
-    /// Searches pattern tokens and returns ids sorted by relevance.
-    ///
-    /// Search engine also applies tokenizer to the
-    /// provided tokens. Use this method when you have
-    /// special tokenization rules in addition to the built-in ones.
-    ///
-    /// Additionally, note that each pattern token must be an ASCII
-    /// string if Levenshtein distance is used.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use simsearch::SimSearch;
-    ///
-    /// let mut engine: SimSearch<u32> = SimSearch::new();
-    ///
-    /// engine.insert(1, "Things Fall Apart");
-    /// engine.insert(2, "The Old Man and the Sea");
-    /// engine.insert(3, "James Joyce");
-    ///
-    /// let results: Vec<u32> = engine.search_tokens(&["thngs", "apa"]);
-    ///
-    /// assert_eq!(results, &[1]);
-    /// ```
-    pub fn search_tokens(&self, pattern_tokens: &[&str]) -> Vec<Id> {
-        self.search_tokens_with_scores(pattern_tokens)
+        let candidates = self.collect_candidates(&pattern_tokens);
+        let mut results: Vec<RankedResult<Id>> = candidates
             .into_iter()
-            .map(|(id, _score)| id)
-            .collect()
-    }
-
-    /// Searches pattern tokens and returns ids with scores sorted by relevance.
-    ///
-    /// Search engine also applies tokenizer to the
-    /// provided tokens. Use this method when you have
-    /// special tokenization rules in addition to the built-in ones.
-    ///
-    /// Additionally, note that each pattern token must be an ASCII
-    /// string if Levenshtein distance is used.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use simsearch::SimSearch;
-    ///
-    /// let mut engine: SimSearch<u32> = SimSearch::new();
-    ///
-    /// engine.insert(1, "Things Fall Apart");
-    ///
-    /// let results: Vec<(u32, f64)> = engine.search_tokens_with_scores(&["thngs"]);
-    ///
-    /// assert_eq!(results[0].0, 1);
-    /// ```
-    pub fn search_tokens_with_scores(&self, pattern_tokens: &[&str]) -> Vec<(Id, f64)> {
-        let mut pattern_tokens = self.tokenize(pattern_tokens);
-        pattern_tokens.sort();
-
-        let mut token_scores: HashMap<&str, f64> = HashMap::new();
-
-        for pattern_token in pattern_tokens {
-            for token in self.reverse_map.keys() {
-                let score = if self.option.levenshtein {
-                    let len = max(token.len(), pattern_token.len()) as f64;
-                    // calculate k (based on the threshold) to bound the Levenshtein distance
-                    let k = ((1.0 - self.option.threshold) * len).ceil() as u32;
-
-                    // cheap prefilter: if length difference already exceeds k,
-                    // levenshtein_simd_k would return None, so skip calling it.
-                    let tlen = token.len() as i32;
-                    let plen = pattern_token.len() as i32;
-                    if (tlen - plen).unsigned_abs() > k {
-                        f64::MIN
-                    } else {
-                        // levenshtein_simd_k only works on ASCII byte slices, so the token strings
-                        // are directly treated as byte slices
-                        match levenshtein_simd_k(token.as_bytes(), pattern_token.as_bytes(), k) {
-                            Some(dist) => 1.0 - if len == 0.0 { 0.0 } else { (dist as f64) / len },
-                            None => f64::MIN,
-                        }
-                    }
-                } else {
-                    jaro_winkler(token, &pattern_token)
-                };
-
-                if score > self.option.threshold {
-                    token_scores
-                        .entry(token.as_str())
-                        .and_modify(|existing_score| {
-                            if score > *existing_score {
-                                *existing_score = score;
-                            }
-                        })
-                        .or_insert(score);
-                }
-            }
-        }
-
-        let mut result_scores: HashMap<usize, f64> = HashMap::new();
-
-        for (token, score) in token_scores.drain() {
-            for id_num in &self.reverse_map[token] {
-                *result_scores.entry(*id_num).or_insert(0.) += score;
-            }
-        }
-
-        let mut result_scores: Vec<(Id, f64)> = result_scores
-            .drain()
-            .map(|(id_num, score)| {
+            .filter_map(|id_num| {
+                let tokens = self.forward_map.get(&id_num)?;
+                let rank = self.rank_document(&pattern_tokens, tokens)?;
                 let id = self
                     .reverse_ids_map
                     .get(&id_num)
@@ -330,18 +329,123 @@ where
                     // inconsistent state
                     .expect("id at id_num should be there")
                     .to_owned();
-                (id, score)
+                Some(RankedResult { id_num, id, rank })
             })
             .collect();
 
-        result_scores.sort_by(|(lhs_id, lhs_score), (rhs_id, rhs_score)| {
-            match rhs_score.partial_cmp(lhs_score).unwrap() {
-                Ordering::Equal => lhs_id.cmp(rhs_id),
-                ord => ord,
+        results.sort_by(|lhs, rhs| self.compare_ranked_results(lhs, rhs));
+        results.truncate(self.options.limit);
+        results
+    }
+
+    fn collect_candidates(&self, pattern_tokens: &[String]) -> HashSet<usize> {
+        let mut candidates = HashSet::new();
+        for pattern_token in pattern_tokens {
+            for (token, id_nums) in &self.reverse_map {
+                if self.token_similarity(pattern_token, token).is_some() {
+                    for id_num in id_nums {
+                        candidates.insert(*id_num);
+                    }
+                }
             }
+        }
+        candidates
+    }
+
+    fn rank_document(&self, pattern_tokens: &[String], tokens: &[String]) -> Option<Rank> {
+        if tokens.is_empty() {
+            return None;
+        }
+
+        let mut matches_by_query = Vec::with_capacity(pattern_tokens.len());
+        for (query_index, pattern_token) in pattern_tokens.iter().enumerate() {
+            let mut matches = Vec::new();
+            for (doc_index, token) in tokens.iter().enumerate() {
+                if let Some(similarity) = self.token_similarity(pattern_token, token) {
+                    matches.push(TokenMatch {
+                        query_index,
+                        doc_index,
+                        score: similarity.score,
+                        typo_cost: similarity.typo_cost,
+                        exact: similarity.exact,
+                    });
+                }
+            }
+            matches.sort_by(Self::compare_token_matches);
+            matches_by_query.push(matches);
+        }
+
+        let mut query_order: Vec<usize> = (0..pattern_tokens.len()).collect();
+        query_order.sort_by(|lhs, rhs| {
+            matches_by_query[*lhs]
+                .len()
+                .cmp(&matches_by_query[*rhs].len())
+                .then_with(|| lhs.cmp(rhs))
         });
 
-        result_scores
+        let mut used_tokens = vec![false; tokens.len()];
+        let mut selected = Vec::new();
+        for query_index in query_order {
+            for token_match in &matches_by_query[query_index] {
+                if !used_tokens[token_match.doc_index] {
+                    used_tokens[token_match.doc_index] = true;
+                    selected.push(token_match.clone());
+                    break;
+                }
+            }
+        }
+
+        if selected.is_empty() {
+            return None;
+        }
+
+        selected.sort_by_key(|token_match| token_match.query_index);
+        Some(Rank::from_matches(
+            &selected,
+            pattern_tokens.len(),
+            tokens.len(),
+        ))
+    }
+
+    fn compare_ranked_results(&self, lhs: &RankedResult<Id>, rhs: &RankedResult<Id>) -> Ordering {
+        rhs.rank
+            .score
+            .partial_cmp(&lhs.rank.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| lhs.id_num.cmp(&rhs.id_num))
+    }
+
+    fn compare_token_matches(lhs: &TokenMatch, rhs: &TokenMatch) -> Ordering {
+        rhs.exact
+            .cmp(&lhs.exact)
+            .then_with(|| lhs.typo_cost.cmp(&rhs.typo_cost))
+            .then_with(|| rhs.score.partial_cmp(&lhs.score).unwrap_or(Ordering::Equal))
+            .then_with(|| lhs.doc_index.cmp(&rhs.doc_index))
+            .then_with(|| lhs.query_index.cmp(&rhs.query_index))
+    }
+
+    fn token_similarity(&self, pattern_token: &str, token: &str) -> Option<TokenSimilarity> {
+        let exact = pattern_token == token;
+        let score = jaro_winkler(token, pattern_token);
+        let typo_cost = Self::typo_cost_from_score(score, max(token.len(), pattern_token.len()));
+
+        if score > 0.0 {
+            Some(TokenSimilarity {
+                score,
+                typo_cost,
+                exact,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn typo_cost_from_score(score: f64, len: usize) -> usize {
+        if score >= 1.0 {
+            0
+        } else {
+            ((1.0 - score) * len as f64).ceil() as usize
+        }
     }
 
     /// Remove an entry by id.
@@ -372,18 +476,9 @@ where
     }
 
     fn tokenize(&self, tokens: &[&str]) -> Vec<String> {
-        let tokens: Vec<String> = tokens
-            .iter()
-            .map(|token| {
-                if self.option.case_sensitive {
-                    token.to_string()
-                } else {
-                    token.to_lowercase()
-                }
-            })
-            .collect();
+        let tokens = self.normalize_tokens(tokens);
 
-        let mut tokens: Vec<String> = if self.option.stop_whitespace {
+        let mut tokens: Vec<String> = if self.options.split_whitespace {
             tokens
                 .iter()
                 .flat_map(|token| token.split_whitespace())
@@ -393,10 +488,10 @@ where
             tokens
         };
 
-        for stop_word in &self.option.stop_words {
+        for separator in &self.options.separators {
             tokens = tokens
                 .iter()
-                .flat_map(|token| token.split_terminator(stop_word.as_str()))
+                .flat_map(|token| token.split_terminator(separator.as_str()))
                 .map(|token| token.to_string())
                 .collect();
         }
@@ -405,127 +500,121 @@ where
 
         tokens
     }
+
+    fn normalize_tokens(&self, tokens: &[&str]) -> Vec<String> {
+        let mut tokens: Vec<String> = tokens
+            .iter()
+            .map(|token| {
+                if self.options.case_sensitive {
+                    token.to_string()
+                } else {
+                    token.to_lowercase()
+                }
+            })
+            .collect();
+
+        tokens.retain(|token| !token.is_empty());
+
+        tokens
+    }
 }
 
-/// Options and flags that configuring the search engine.
+/// Options for configuring the search index.
 ///
 /// # Examples
 ///
 /// ```
-/// use simsearch::{SearchOptions, SimSearch};
+/// use simsearch::{Options, Index};
 ///
-/// let mut engine: SimSearch<usize> = SimSearch::new_with(
-///     SearchOptions::new().case_sensitive(true));
+/// let mut engine: Index<usize> = Index::with_options(
+///     Options::new().case_sensitive(true));
 /// ```
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct SearchOptions {
+pub struct Options {
     case_sensitive: bool,
-    stop_whitespace: bool,
-    stop_words: Vec<String>,
-    threshold: f64,
-    levenshtein: bool,
+    split_whitespace: bool,
+    separators: Vec<String>,
+    limit: usize,
 }
 
-impl SearchOptions {
+impl Options {
     /// Creates a default configuration.
     pub fn new() -> Self {
-        SearchOptions {
+        Options {
             case_sensitive: false,
-            stop_whitespace: true,
-            stop_words: vec![],
-            threshold: 0.8,
-            levenshtein: false,
+            split_whitespace: true,
+            separators: vec![],
+            limit: 10,
         }
     }
 
-    /// Sets whether search engine is case sensitive or not.
+    /// Sets whether the index is case sensitive.
     ///
     /// Defaults to `false`.
     pub fn case_sensitive(self, case_sensitive: bool) -> Self {
-        SearchOptions {
+        Options {
             case_sensitive,
             ..self
         }
     }
 
-    /// Sets the whether search engine splits tokens on whitespace or not.
-    /// The **whitespace** here includes tab, returns and so forth.
+    /// Sets whether the index splits tokens on whitespace.
+    /// Whitespace includes spaces, tabs, returns, and similar characters.
     ///
     /// See also [`std::str::split_whitespace()`](https://doc.rust-lang.org/std/primitive.str.html#method.split_whitespace).
     ///
     /// Defaults to `true`.
-    pub fn stop_whitespace(self, stop_whitespace: bool) -> Self {
-        SearchOptions {
-            stop_whitespace,
+    pub fn split_whitespace(self, split_whitespace: bool) -> Self {
+        Options {
+            split_whitespace,
             ..self
         }
     }
 
-    /// Sets the custom token stop word.
+    /// Sets custom token separators.
     ///
-    /// This option enables tokenizer to split contents
-    /// and search words by the extra list of custom stop words.
+    /// This option enables the tokenizer to split indexed fields and search
+    /// queries by the extra list of custom separators.
     ///
     /// Defaults to `&[]`.
     ///
     /// # Examples
     /// ```
-    /// use simsearch::{SearchOptions, SimSearch};
+    /// use simsearch::{Options, Index};
     ///
-    /// let mut engine: SimSearch<usize> = SimSearch::new_with(
-    ///     SearchOptions::new().stop_words(vec!["/".to_string(), "\\".to_string()]));
+    /// let mut engine: Index<usize> = Index::with_options(
+    ///     Options::new().separators(vec!["/".to_string(), "\\".to_string()]));
     ///
     /// engine.insert(1, "the old/man/and/the sea");
     ///
     /// let results = engine.search("old");
     ///
-    /// assert_eq!(results, &[1]);
+    /// assert_eq!(results[0].id, 1);
     /// ```
-    pub fn stop_words(self, stop_words: Vec<String>) -> Self {
-        SearchOptions { stop_words, ..self }
+    pub fn separators(self, separators: Vec<String>) -> Self {
+        Options { separators, ..self }
     }
 
-    /// Sets the threshold for search scoring.
+    /// Sets the maximum number of results returned by a search.
     ///
-    /// Search results will be sorted by their Jaro winkler similarity scores.
-    /// Scores ranges from 0 to 1 where the 1 indicates the most relevant.
-    /// Only the entries with scores greater than the threshold will be returned.
-    ///
-    /// Defaults to `0.8`.
-    pub fn threshold(self, threshold: f64) -> Self {
-        SearchOptions { threshold, ..self }
-    }
-
-    /// Sets whether Levenshtein distance, which is SIMD-accelerated, should be
-    /// used instead of the default Jaro-Winkler distance.
-    ///
-    /// The implementation of Levenshtein distance is very fast but cannot handle Unicode
-    /// strings, unlike the default Jaro-Winkler distance. The strings are treated as byte
-    /// slices with Levenshtein distance, which means that the calculated score may be
-    /// incorrectly lower for Unicode strings, where each character is represented with
-    /// multiple bytes.
-    ///
-    /// Defaults to `false`.
-    pub fn levenshtein(self, levenshtein: bool) -> Self {
-        SearchOptions {
-            levenshtein,
-            ..self
-        }
+    /// Defaults to `10`.
+    pub fn limit(self, limit: usize) -> Self {
+        Options { limit, ..self }
     }
 }
 
-impl<Id> Default for SimSearch<Id>
+impl<Id> Default for Index<Id>
 where
-    Id: Eq + PartialEq + Clone + Hash + Ord,
+    Id: Eq + Clone + Hash,
 {
     fn default() -> Self {
-        SimSearch::new()
+        Index::new()
     }
 }
 
-impl Default for SearchOptions {
+impl Default for Options {
     fn default() -> Self {
-        SearchOptions::new()
+        Options::new()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,8 +312,9 @@ where
     /// The query is tokenized according to the index options.
     /// By default, whitespace, including tabs, is treated as a separator.
     /// Use [`Options`] to change tokenization behavior.
-    /// Search matches exact terms, the last query term as a prefix, and
-    /// typo-tolerant terms when those options are enabled.
+    /// Search matches exact terms, typo-tolerant terms, and the last query
+    /// term as a prefix, including typo-tolerant prefixes when both options are
+    /// enabled.
     ///
     /// # Examples
     ///
@@ -581,6 +582,10 @@ where
                             exact: false,
                         },
                     );
+                } else if self.options.prefix_search && prefix_search {
+                    if let Some(similarity) = Self::prefix_typo_similarity(pattern_token, term) {
+                        Self::insert_candidate(&mut candidates, term, similarity);
+                    }
                 }
             }
         }
@@ -654,10 +659,25 @@ where
         1.0 - typo_cost as f64 / (len + 1) as f64
     }
 
+    fn prefix_typo_similarity(pattern_token: &str, term: &str) -> Option<TokenSimilarity> {
+        let max_typos = Self::allowed_typos(pattern_token);
+        let prefix_len = pattern_token.chars().count() + max_typos;
+        let term_prefix: String = term.chars().take(prefix_len).collect();
+        let typo_cost = Self::edit_distance_at_most(pattern_token, &term_prefix, max_typos)?;
+        let score = Self::typo_score(pattern_token, &term_prefix, typo_cost)
+            .min(Self::prefix_score(pattern_token, term));
+
+        Some(TokenSimilarity {
+            score,
+            typo_cost,
+            exact: false,
+        })
+    }
+
     fn allowed_typos(token: &str) -> usize {
         match token.chars().count() {
-            0..=4 => 0,
-            5..=8 => 1,
+            0..=2 => 0,
+            3..=5 => 1,
             _ => 2,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,9 +211,9 @@ where
     /// Inserts an entry into the index.
     ///
     /// The content is tokenized according to the index options.
-    /// By default, [`char::is_ascii_whitespace`] characters are treated as
+    /// By default, [`char::is_whitespace`] characters are treated as
     /// separators.
-    /// Use [`Options`] to change tokenization behavior.
+    /// Use [`Options`] to add more separators.
     ///
     /// Inserting an existing ID updates its content.
     ///
@@ -225,14 +225,8 @@ where
     /// ```
     /// use simsearch::{Options, Index};
     ///
-    /// let mut separators: Vec<char> = (0..=u8::MAX)
-    ///     .map(char::from)
-    ///     .filter(char::is_ascii_whitespace)
-    ///     .collect();
-    /// separators.extend([',', '.']);
-    ///
     /// let mut engine: Index<&str> = Index::with_options(
-    ///     Options::new().separators(separators));
+    ///     Options::new().separators([',', '.', '/']));
     ///
     /// engine.insert("BoJack Horseman", "BoJack Horseman, an American
     /// adult animated comedy-drama series created by Raphael Bob-Waksberg.
@@ -315,9 +309,9 @@ where
     /// relevance.
     ///
     /// The query is tokenized according to the index options.
-    /// By default, [`char::is_ascii_whitespace`] characters are treated as
+    /// By default, [`char::is_whitespace`] characters are treated as
     /// separators.
-    /// Use [`Options`] to change tokenization behavior.
+    /// Use [`Options`] to add more separators.
     /// Search matches exact terms, typo-tolerant terms, and the last query
     /// term as a prefix, including typo-tolerant prefixes when both options are
     /// enabled.
@@ -713,18 +707,19 @@ where
     }
 
     fn tokenize(&self, tokens: &[&str]) -> Vec<String> {
-        let mut tokens = self.normalize_tokens(tokens);
-        for separator in &self.options.separators {
-            tokens = tokens
-                .iter()
-                .flat_map(|token| token.split_terminator(*separator))
-                .map(|token| token.to_string())
-                .collect();
-        }
-
-        tokens.retain(|token| !token.is_empty());
-
+        let tokens = self.normalize_tokens(tokens);
         tokens
+            .into_iter()
+            .flat_map(|token| {
+                token
+                    .split(|ch: char| {
+                        ch.is_whitespace() || self.options.extra_separators.contains(&ch)
+                    })
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|token| !token.is_empty())
+            .collect()
     }
 
     fn normalize_tokens(&self, tokens: &[&str]) -> Vec<String> {
@@ -762,7 +757,7 @@ pub struct Options {
     prefix_search: bool,
     typo_tolerance: bool,
     case_sensitive: bool,
-    separators: Vec<char>,
+    extra_separators: Vec<char>,
 }
 
 impl Options {
@@ -773,7 +768,7 @@ impl Options {
             prefix_search: true,
             typo_tolerance: true,
             case_sensitive: false,
-            separators: Self::default_separators(),
+            extra_separators: Vec::new(),
         }
     }
 
@@ -814,25 +809,20 @@ impl Options {
         }
     }
 
-    /// Sets token separators.
+    /// Adds token separators.
     ///
-    /// This option enables the tokenizer to split indexed parts and search
-    /// queries by the configured separators.
+    /// Indexed parts and search queries are always split by
+    /// [`char::is_whitespace`] characters. This option adds more
+    /// separators on top of that default behavior.
     ///
-    /// Defaults to [`char::is_ascii_whitespace`] characters.
+    /// Defaults to no extra separators.
     ///
     /// # Examples
     /// ```
     /// use simsearch::{Options, Index};
     ///
-    /// let mut separators: Vec<char> = (0..=u8::MAX)
-    ///     .map(char::from)
-    ///     .filter(char::is_ascii_whitespace)
-    ///     .collect();
-    /// separators.extend(['/', '\\']);
-    ///
     /// let mut engine: Index<usize> = Index::with_options(
-    ///     Options::new().separators(separators));
+    ///     Options::new().separators(['/', '\\']));
     ///
     /// engine.insert(1, "the old/man/and/the sea");
     ///
@@ -845,16 +835,9 @@ impl Options {
         I: IntoIterator<Item = char>,
     {
         Options {
-            separators: separators.into_iter().collect(),
+            extra_separators: separators.into_iter().collect(),
             ..self
         }
-    }
-
-    fn default_separators() -> Vec<char> {
-        (0..=u8::MAX)
-            .map(char::from)
-            .filter(char::is_ascii_whitespace)
-            .collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,14 +212,14 @@ where
 
     /// Inserts an entry into the index.
     ///
-    /// Input will be tokenized according to the search option.
-    /// By default whitespaces(including tabs) are considered as separators,
-    /// you can change the behavior by providing `Options`.
+    /// The content is tokenized according to the index options.
+    /// By default, whitespace, including tabs, is treated as a separator.
+    /// Use [`Options`] to change tokenization behavior.
     ///
-    /// Insert with an existing id updates the content.
+    /// Inserting an existing ID updates its content.
     ///
-    /// **Note that** id is not searchable. Add id to the contents if you would
-    /// like to perform search on it.
+    /// The ID itself is not searchable. Include it in the content if you want
+    /// searches to match it.
     ///
     /// # Examples
     ///
@@ -246,10 +246,10 @@ where
     /// [`Index::insert`]. This is useful when an item has several searchable
     /// parts, such as a title, author, tags, or aliases.
     ///
-    /// Insert with an existing id updates the content.
+    /// Inserting an existing ID updates its content.
     ///
-    /// **Note that** id is not searchable. Add id to the contents if you would
-    /// like to perform search on it.
+    /// The ID itself is not searchable. Include it in the content if you want
+    /// searches to match it.
     ///
     /// # Examples
     ///
@@ -309,9 +309,9 @@ where
     /// Searches pattern and returns up to [`Options::limit`] hits sorted by
     /// relevance.
     ///
-    /// Pattern will be tokenized according to the search option.
-    /// By default whitespaces(including tabs) are considered as separators,
-    /// you can change the behavior by providing `Options`.
+    /// The query is tokenized according to the index options.
+    /// By default, whitespace, including tabs, is treated as a separator.
+    /// Use [`Options`] to change tokenization behavior.
     /// Search matches exact terms, the last query term as a prefix, and
     /// typo-tolerant terms when those options are enabled.
     ///
@@ -758,7 +758,7 @@ where
         (distance <= max_distance).then_some(distance)
     }
 
-    /// Remove an entry by id.
+    /// Removes an entry by ID.
     pub fn remove(&mut self, id: &Id) {
         if let Some(id_num) = self.ids_map.get(id).copied() {
             if let Some(tokens) = self.forward_map.remove(&id_num) {
@@ -778,7 +778,7 @@ where
         };
     }
 
-    /// Clear all entries.
+    /// Clears all entries.
     pub fn clear(&mut self) {
         self.id_num_counter = 0;
         self.ids_map.clear();
@@ -920,9 +920,9 @@ impl Options {
     /// Sets custom token separators.
     ///
     /// This option enables the tokenizer to split indexed parts and search
-    /// queries by the extra list of custom separators.
+    /// queries by the configured custom separators.
     ///
-    /// Defaults to `&[]`.
+    /// Defaults to an empty list.
     ///
     /// # Examples
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
+use std::ops::Bound;
 
 use strsim::jaro_winkler;
 
@@ -279,7 +280,7 @@ where
     /// Alison Brie, Paul F. Tompkins, and Aaron Paul.");
     /// ```
     pub fn insert(&mut self, id: Id, content: &str) {
-        let tokens = self.tokenize(&[content]);
+        let tokens = self.tokenize([content]);
         self.insert_normalized_tokens(id, tokens)
     }
 
@@ -316,22 +317,21 @@ where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let parts: Vec<String> = parts
-            .into_iter()
-            .map(|part| part.as_ref().to_string())
-            .collect();
-        let parts: Vec<&str> = parts.iter().map(String::as_str).collect();
-        let tokens = self.tokenize(&parts);
+        let tokens = self.tokenize(parts);
         self.insert_normalized_tokens(id, tokens)
     }
 
     fn insert_normalized_tokens(&mut self, id: Id, tokens: Vec<String>) {
-        self.remove(&id);
-
-        let id_num = self.id_num_counter;
-        self.ids_map.insert(id.clone(), id_num);
-        self.reverse_ids_map.insert(id_num, id);
-        self.id_num_counter += 1;
+        let id_num = if let Some(id_num) = self.ids_map.get(&id).copied() {
+            self.remove_indexed_tokens(id_num);
+            id_num
+        } else {
+            let id_num = self.id_num_counter;
+            self.ids_map.insert(id.clone(), id_num);
+            self.reverse_ids_map.insert(id_num, id);
+            self.id_num_counter += 1;
+            id_num
+        };
 
         for (position, token) in tokens.iter().enumerate() {
             if !self.reverse_map.contains_key(token) {
@@ -377,7 +377,7 @@ where
     /// assert!(results[0].score > 0.0);
     /// ```
     pub fn search(&self, pattern: &str) -> Vec<Hit<Id>> {
-        self.search_ranked(self.tokenize(&[pattern]))
+        self.search_ranked(self.tokenize([pattern]))
             .into_iter()
             .map(|result| Hit {
                 id: result.id,
@@ -671,7 +671,7 @@ where
         }
 
         self.terms
-            .range(prefix.to_string()..)
+            .range::<str, _>((Bound::Included(prefix), Bound::Unbounded))
             .take_while(|term| term.starts_with(prefix))
             .map(String::as_str)
             .collect()
@@ -728,22 +728,25 @@ where
         self.terms.remove(term);
     }
 
-    /// Removes an entry by ID.
-    pub fn remove(&mut self, id: &Id) {
-        if let Some(id_num) = self.ids_map.get(id).copied() {
-            if let Some(tokens) = self.forward_map.remove(&id_num) {
-                let unique_tokens = tokens.into_iter().collect::<HashSet<_>>();
-                for token in unique_tokens {
-                    if let Some(postings) = self.reverse_map.get_mut(&token) {
-                        postings.remove(&id_num);
-                        if postings.is_empty() {
-                            self.reverse_map.remove(&token);
-                            self.remove_term(&token);
-                        }
+    fn remove_indexed_tokens(&mut self, id_num: usize) {
+        if let Some(tokens) = self.forward_map.remove(&id_num) {
+            let unique_tokens = tokens.into_iter().collect::<HashSet<_>>();
+            for token in unique_tokens {
+                if let Some(postings) = self.reverse_map.get_mut(&token) {
+                    postings.remove(&id_num);
+                    if postings.is_empty() {
+                        self.reverse_map.remove(&token);
+                        self.remove_term(&token);
                     }
                 }
             }
-            self.ids_map.remove(id);
+        }
+    }
+
+    /// Removes an entry by ID.
+    pub fn remove(&mut self, id: &Id) {
+        if let Some(id_num) = self.ids_map.remove(id) {
+            self.remove_indexed_tokens(id_num);
             self.reverse_ids_map.remove(&id_num);
         }
     }
@@ -758,35 +761,27 @@ where
         self.terms.clear();
     }
 
-    fn tokenize(&self, tokens: &[&str]) -> Vec<String> {
-        let tokens = self.normalize_tokens(tokens);
-        tokens
-            .into_iter()
-            .flat_map(|token| {
-                token
-                    .split(|ch: char| {
-                        ch.is_whitespace() || self.options.extra_separators.contains(&ch)
-                    })
-                    .map(str::to_string)
-                    .collect::<Vec<_>>()
-            })
-            .filter(|token| !token.is_empty())
-            .collect()
-    }
+    fn tokenize<I, S>(&self, parts: I) -> Vec<String>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut tokens = Vec::new();
+        for part in parts {
+            let part = if self.options.case_sensitive {
+                part.as_ref().to_string()
+            } else {
+                part.as_ref().to_lowercase()
+            };
 
-    fn normalize_tokens(&self, tokens: &[&str]) -> Vec<String> {
-        let mut tokens: Vec<String> = tokens
-            .iter()
-            .map(|token| {
-                if self.options.case_sensitive {
-                    token.to_string()
-                } else {
-                    token.to_lowercase()
+            for token in part
+                .split(|ch: char| ch.is_whitespace() || self.options.extra_separators.contains(&ch))
+            {
+                if !token.is_empty() {
+                    tokens.push(token.to_string());
                 }
-            })
-            .collect();
-
-        tokens.retain(|token| !token.is_empty());
+            }
+        }
 
         tokens
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,11 +272,14 @@ where
         self.reverse_ids_map.insert(id_num, id);
         self.id_num_counter += 1;
 
+        let mut indexed_tokens = HashSet::new();
         for token in tokens.clone() {
-            self.reverse_map
-                .entry(token)
-                .or_insert_with(|| Vec::with_capacity(1))
-                .push(id_num);
+            if indexed_tokens.insert(token.clone()) {
+                self.reverse_map
+                    .entry(token)
+                    .or_insert_with(|| Vec::with_capacity(1))
+                    .push(id_num);
+            }
         }
 
         self.forward_map.insert(id_num, tokens);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,8 @@ where
     /// Inserts an entry into the index.
     ///
     /// The content is tokenized according to the index options.
-    /// By default, whitespace, including tabs, is treated as a separator.
+    /// By default, [`char::is_ascii_whitespace`] characters are treated as
+    /// separators.
     /// Use [`Options`] to change tokenization behavior.
     ///
     /// Inserting an existing ID updates its content.
@@ -224,8 +225,14 @@ where
     /// ```
     /// use simsearch::{Options, Index};
     ///
+    /// let mut separators: Vec<char> = (0..=u8::MAX)
+    ///     .map(char::from)
+    ///     .filter(char::is_ascii_whitespace)
+    ///     .collect();
+    /// separators.extend([',', '.']);
+    ///
     /// let mut engine: Index<&str> = Index::with_options(
-    ///     Options::new().separators(vec![",".to_string(), ".".to_string()]));
+    ///     Options::new().separators(separators));
     ///
     /// engine.insert("BoJack Horseman", "BoJack Horseman, an American
     /// adult animated comedy-drama series created by Raphael Bob-Waksberg.
@@ -308,7 +315,8 @@ where
     /// relevance.
     ///
     /// The query is tokenized according to the index options.
-    /// By default, whitespace, including tabs, is treated as a separator.
+    /// By default, [`char::is_ascii_whitespace`] characters are treated as
+    /// separators.
     /// Use [`Options`] to change tokenization behavior.
     /// Search matches exact terms, typo-tolerant terms, and the last query
     /// term as a prefix, including typo-tolerant prefixes when both options are
@@ -705,22 +713,11 @@ where
     }
 
     fn tokenize(&self, tokens: &[&str]) -> Vec<String> {
-        let tokens = self.normalize_tokens(tokens);
-
-        let mut tokens: Vec<String> = if self.options.split_whitespace {
-            tokens
-                .iter()
-                .flat_map(|token| token.split_whitespace())
-                .map(|token| token.to_string())
-                .collect()
-        } else {
-            tokens
-        };
-
+        let mut tokens = self.normalize_tokens(tokens);
         for separator in &self.options.separators {
             tokens = tokens
                 .iter()
-                .flat_map(|token| token.split_terminator(separator.as_str()))
+                .flat_map(|token| token.split_terminator(*separator))
                 .map(|token| token.to_string())
                 .collect();
         }
@@ -765,8 +762,7 @@ pub struct Options {
     prefix_search: bool,
     typo_tolerance: bool,
     case_sensitive: bool,
-    split_whitespace: bool,
-    separators: Vec<String>,
+    separators: Vec<char>,
 }
 
 impl Options {
@@ -777,8 +773,7 @@ impl Options {
             prefix_search: true,
             typo_tolerance: true,
             case_sensitive: false,
-            split_whitespace: true,
-            separators: vec![],
+            separators: Self::default_separators(),
         }
     }
 
@@ -819,32 +814,25 @@ impl Options {
         }
     }
 
-    /// Sets whether the index splits tokens on whitespace.
-    /// Whitespace includes spaces, tabs, returns, and similar characters.
-    ///
-    /// See also [`std::str::split_whitespace()`](https://doc.rust-lang.org/std/primitive.str.html#method.split_whitespace).
-    ///
-    /// Defaults to `true`.
-    pub fn split_whitespace(self, split_whitespace: bool) -> Self {
-        Options {
-            split_whitespace,
-            ..self
-        }
-    }
-
-    /// Sets custom token separators.
+    /// Sets token separators.
     ///
     /// This option enables the tokenizer to split indexed parts and search
-    /// queries by the configured custom separators.
+    /// queries by the configured separators.
     ///
-    /// Defaults to an empty list.
+    /// Defaults to [`char::is_ascii_whitespace`] characters.
     ///
     /// # Examples
     /// ```
     /// use simsearch::{Options, Index};
     ///
+    /// let mut separators: Vec<char> = (0..=u8::MAX)
+    ///     .map(char::from)
+    ///     .filter(char::is_ascii_whitespace)
+    ///     .collect();
+    /// separators.extend(['/', '\\']);
+    ///
     /// let mut engine: Index<usize> = Index::with_options(
-    ///     Options::new().separators(vec!["/".to_string(), "\\".to_string()]));
+    ///     Options::new().separators(separators));
     ///
     /// engine.insert(1, "the old/man/and/the sea");
     ///
@@ -852,8 +840,21 @@ impl Options {
     ///
     /// assert_eq!(results[0].id, 1);
     /// ```
-    pub fn separators(self, separators: Vec<String>) -> Self {
-        Options { separators, ..self }
+    pub fn separators<I>(self, separators: I) -> Self
+    where
+        I: IntoIterator<Item = char>,
+    {
+        Options {
+            separators: separators.into_iter().collect(),
+            ..self
+        }
+    }
+
+    fn default_separators() -> Vec<char> {
+        (0..=u8::MAX)
+            .map(char::from)
+            .filter(char::is_ascii_whitespace)
+            .collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,11 +240,11 @@ where
         self.insert_normalized_tokens(id, tokens)
     }
 
-    /// Inserts an entry with multiple searchable fields into the index.
+    /// Inserts an entry with multiple searchable parts into the index.
     ///
-    /// Each field is tokenized with the same built-in tokenizer used by
+    /// Each part is tokenized with the same built-in tokenizer used by
     /// [`Index::insert`]. This is useful when an item has several searchable
-    /// fields, such as a title, author, tags, or aliases.
+    /// parts, such as a title, author, tags, or aliases.
     ///
     /// Insert with an existing id updates the content.
     ///
@@ -258,7 +258,7 @@ where
     ///
     /// let mut engine: Index<&str> = Index::new();
     ///
-    /// engine.insert_many("A Game of Thrones", [
+    /// engine.insert_parts("A Game of Thrones", [
     ///     "A Game of Thrones",
     ///     "George R. R. Martin",
     ///     "fantasy",
@@ -268,17 +268,17 @@ where
     ///
     /// assert_eq!(results[0].id, "A Game of Thrones");
     /// ```
-    pub fn insert_many<I, S>(&mut self, id: Id, fields: I)
+    pub fn insert_parts<I, S>(&mut self, id: Id, parts: I)
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let fields: Vec<String> = fields
+        let parts: Vec<String> = parts
             .into_iter()
-            .map(|field| field.as_ref().to_string())
+            .map(|part| part.as_ref().to_string())
             .collect();
-        let fields: Vec<&str> = fields.iter().map(String::as_str).collect();
-        let tokens = self.tokenize(&fields);
+        let parts: Vec<&str> = parts.iter().map(String::as_str).collect();
+        let tokens = self.tokenize(&parts);
         self.insert_normalized_tokens(id, tokens)
     }
 
@@ -919,7 +919,7 @@ impl Options {
 
     /// Sets custom token separators.
     ///
-    /// This option enables the tokenizer to split indexed fields and search
+    /// This option enables the tokenizer to split indexed parts and search
     /// queries by the extra list of custom separators.
     ///
     /// Defaults to `&[]`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ impl AssignmentState {
 impl Rank {
     fn from_matches(matches: &[TokenMatch], query_len: usize, doc_len: usize) -> Self {
         let matched_terms = matches.len();
-        let proximity_cost = Self::proximity_cost(matches, doc_len);
+        let proximity_cost = Self::proximity_cost(matches);
         let first_position = matches
             .iter()
             .map(|token_match| token_match.doc_index)
@@ -194,7 +194,7 @@ impl Rank {
         }
     }
 
-    fn proximity_cost(matches: &[TokenMatch], doc_len: usize) -> usize {
+    fn proximity_cost(matches: &[TokenMatch]) -> usize {
         if matches.len() < 2 {
             return 0;
         }
@@ -203,11 +203,7 @@ impl Rank {
         for window in matches.windows(2) {
             let lhs = window[0].doc_index;
             let rhs = window[1].doc_index;
-            if rhs > lhs {
-                cost += rhs - lhs - 1;
-            } else {
-                cost += doc_len + lhs - rhs + 1;
-            }
+            cost += rhs - lhs - 1;
         }
         cost
     }
@@ -749,7 +745,7 @@ where
             }
             self.ids_map.remove(id);
             self.reverse_ids_map.remove(&id_num);
-        };
+        }
     }
 
     /// Clears all entries.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! assert_eq!(results[0].id, 1);
 //! ```
 
-use std::cmp::{Ordering, max};
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
@@ -79,14 +79,12 @@ struct TokenMatch {
     query_index: usize,
     doc_index: usize,
     score: f64,
-    typo_cost: usize,
     exact: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct TokenSimilarity {
     score: f64,
-    typo_cost: usize,
     exact: bool,
 }
 
@@ -371,7 +369,6 @@ where
                         query_index,
                         doc_index,
                         score: similarity.score,
-                        typo_cost: similarity.typo_cost,
                         exact: similarity.exact,
                     });
                 }
@@ -413,7 +410,6 @@ where
     fn compare_token_matches(lhs: &TokenMatch, rhs: &TokenMatch) -> Ordering {
         rhs.exact
             .cmp(&lhs.exact)
-            .then_with(|| lhs.typo_cost.cmp(&rhs.typo_cost))
             .then_with(|| rhs.score.partial_cmp(&lhs.score).unwrap_or(Ordering::Equal))
             .then_with(|| lhs.doc_index.cmp(&rhs.doc_index))
             .then_with(|| lhs.query_index.cmp(&rhs.query_index))
@@ -422,24 +418,11 @@ where
     fn token_similarity(&self, pattern_token: &str, token: &str) -> Option<TokenSimilarity> {
         let exact = pattern_token == token;
         let score = jaro_winkler(token, pattern_token);
-        let typo_cost = Self::typo_cost_from_score(score, max(token.len(), pattern_token.len()));
 
         if score > 0.0 {
-            Some(TokenSimilarity {
-                score,
-                typo_cost,
-                exact,
-            })
+            Some(TokenSimilarity { score, exact })
         } else {
             None
-        }
-    }
-
-    fn typo_cost_from_score(score: f64, len: usize) -> usize {
-        if score >= 1.0 {
-            0
-        } else {
-            ((1.0 - score) * len as f64).ceil() as usize
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,8 @@
 //! ```
 
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
-
-use strsim::jaro_winkler;
 
 const QUALITY_WEIGHT: f64 = 0.68;
 const COVERAGE_WEIGHT: f64 = 0.14;
@@ -29,6 +27,9 @@ const PROXIMITY_WEIGHT: f64 = 0.07;
 const EXACTNESS_WEIGHT: f64 = 0.04;
 const POSITION_WEIGHT: f64 = 0.03;
 const SPECIFICITY_WEIGHT: f64 = 0.04;
+const MAX_ASSIGNMENT_STATES: usize = 64;
+
+type PostingMap = HashMap<usize, Vec<usize>>;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -45,7 +46,9 @@ where
     ids_map: HashMap<Id, usize>,
     reverse_ids_map: HashMap<usize, Id>,
     forward_map: HashMap<usize, Vec<String>>,
-    reverse_map: HashMap<String, Vec<usize>>,
+    reverse_map: HashMap<String, PostingMap>,
+    terms: BTreeSet<String>,
+    typo_map: HashMap<String, HashSet<String>>,
 }
 
 /// A search result with its normalized relevance score.
@@ -79,13 +82,28 @@ struct TokenMatch {
     query_index: usize,
     doc_index: usize,
     score: f64,
+    typo_cost: usize,
     exact: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct TokenSimilarity {
     score: f64,
+    typo_cost: usize,
     exact: bool,
+}
+
+#[derive(Debug, Clone)]
+struct TermCandidate {
+    term: String,
+    similarity: TokenSimilarity,
+}
+
+#[derive(Debug, Clone)]
+struct AssignmentState {
+    selected: Vec<TokenMatch>,
+    used_tokens: Vec<bool>,
+    rank: Rank,
 }
 
 impl Rank {
@@ -187,6 +205,8 @@ where
             reverse_ids_map: HashMap::new(),
             forward_map: HashMap::new(),
             reverse_map: HashMap::new(),
+            terms: BTreeSet::new(),
+            typo_map: HashMap::new(),
         }
     }
 
@@ -270,24 +290,30 @@ where
         self.reverse_ids_map.insert(id_num, id);
         self.id_num_counter += 1;
 
-        let mut indexed_tokens = HashSet::new();
-        for token in tokens.clone() {
-            if indexed_tokens.insert(token.clone()) {
-                self.reverse_map
-                    .entry(token)
-                    .or_insert_with(|| Vec::with_capacity(1))
-                    .push(id_num);
+        for (position, token) in tokens.iter().enumerate() {
+            if !self.reverse_map.contains_key(token) {
+                self.add_term(token);
             }
+
+            self.reverse_map
+                .entry(token.clone())
+                .or_default()
+                .entry(id_num)
+                .or_default()
+                .push(position);
         }
 
         self.forward_map.insert(id_num, tokens);
     }
 
-    /// Searches pattern and returns hits sorted by relevance.
+    /// Searches pattern and returns up to [`Options::limit`] hits sorted by
+    /// relevance.
     ///
     /// Pattern will be tokenized according to the search option.
     /// By default whitespaces(including tabs) are considered as separators,
     /// you can change the behavior by providing `Options`.
+    /// Search matches exact terms, the last query term as a prefix, and
+    /// typo-tolerant terms when those options are enabled.
     ///
     /// # Examples
     ///
@@ -320,12 +346,12 @@ where
             return Vec::new();
         }
 
-        let candidates = self.collect_candidates(&pattern_tokens);
-        let mut results: Vec<RankedResult<Id>> = candidates
+        let matches_by_document = self.collect_matches(&pattern_tokens);
+        let mut results: Vec<RankedResult<Id>> = matches_by_document
             .into_iter()
-            .filter_map(|id_num| {
+            .filter_map(|(id_num, matches)| {
                 let tokens = self.forward_map.get(&id_num)?;
-                let rank = self.rank_document(&pattern_tokens, tokens)?;
+                let rank = self.rank_document(&pattern_tokens, tokens, matches)?;
                 let id = self
                     .reverse_ids_map
                     .get(&id_num)
@@ -342,61 +368,148 @@ where
         results
     }
 
-    fn collect_candidates(&self, pattern_tokens: &[String]) -> HashSet<usize> {
-        let mut candidates = HashSet::new();
-        for pattern_token in pattern_tokens {
-            for (token, id_nums) in &self.reverse_map {
-                if self.token_similarity(pattern_token, token).is_some() {
-                    for id_num in id_nums {
-                        candidates.insert(*id_num);
+    fn collect_matches(&self, pattern_tokens: &[String]) -> HashMap<usize, Vec<TokenMatch>> {
+        let mut matches_by_document: HashMap<usize, Vec<TokenMatch>> = HashMap::new();
+
+        for (query_index, pattern_token) in pattern_tokens.iter().enumerate() {
+            let is_last_query_token = query_index + 1 == pattern_tokens.len();
+            for candidate in self.expand_query_term(pattern_token, is_last_query_token) {
+                if let Some(postings) = self.reverse_map.get(&candidate.term) {
+                    for (id_num, positions) in postings {
+                        let matches = matches_by_document.entry(*id_num).or_default();
+                        for doc_index in positions {
+                            matches.push(TokenMatch {
+                                query_index,
+                                doc_index: *doc_index,
+                                score: candidate.similarity.score,
+                                typo_cost: candidate.similarity.typo_cost,
+                                exact: candidate.similarity.exact,
+                            });
+                        }
                     }
                 }
             }
         }
-        candidates
+
+        matches_by_document
     }
 
-    fn rank_document(&self, pattern_tokens: &[String], tokens: &[String]) -> Option<Rank> {
+    fn rank_document(
+        &self,
+        pattern_tokens: &[String],
+        tokens: &[String],
+        matches: Vec<TokenMatch>,
+    ) -> Option<Rank> {
         if tokens.is_empty() {
             return None;
         }
 
-        let mut matches = Vec::new();
-        for (query_index, pattern_token) in pattern_tokens.iter().enumerate() {
-            for (doc_index, token) in tokens.iter().enumerate() {
-                if let Some(similarity) = self.token_similarity(pattern_token, token) {
-                    matches.push(TokenMatch {
-                        query_index,
-                        doc_index,
-                        score: similarity.score,
-                        exact: similarity.exact,
-                    });
-                }
-            }
-        }
-        matches.sort_by(Self::compare_token_matches);
+        let mut matches_by_query = vec![Vec::new(); pattern_tokens.len()];
 
-        let mut used_queries = vec![false; pattern_tokens.len()];
-        let mut used_tokens = vec![false; tokens.len()];
-        let mut selected = Vec::new();
         for token_match in matches {
-            if !used_queries[token_match.query_index] && !used_tokens[token_match.doc_index] {
-                used_queries[token_match.query_index] = true;
-                used_tokens[token_match.doc_index] = true;
-                selected.push(token_match);
-            }
+            matches_by_query[token_match.query_index].push(token_match);
         }
 
+        for matches in &mut matches_by_query {
+            matches.sort_by(Self::compare_token_matches);
+        }
+
+        let mut selected = Self::select_best_matches(&matches_by_query, tokens.len());
         if selected.is_empty() {
             return None;
         }
 
         selected.sort_by_key(|token_match| token_match.query_index);
+
         Some(Rank::from_matches(
             &selected,
             pattern_tokens.len(),
             tokens.len(),
         ))
+    }
+
+    fn select_best_matches(
+        matches_by_query: &[Vec<TokenMatch>],
+        doc_len: usize,
+    ) -> Vec<TokenMatch> {
+        let query_len = matches_by_query.len();
+        let mut query_order: Vec<usize> = (0..query_len).collect();
+        query_order.sort_by(|lhs, rhs| {
+            matches_by_query[*lhs]
+                .len()
+                .cmp(&matches_by_query[*rhs].len())
+                .then_with(|| lhs.cmp(rhs))
+        });
+
+        let mut states = vec![AssignmentState {
+            selected: Vec::new(),
+            used_tokens: vec![false; doc_len],
+            rank: Rank { score: 0.0 },
+        }];
+
+        for query_index in query_order {
+            let matches = &matches_by_query[query_index];
+            if matches.is_empty() {
+                continue;
+            }
+
+            let mut next_states = Vec::new();
+            for state in &states {
+                next_states.push(state.clone());
+
+                for token_match in matches {
+                    if state.used_tokens[token_match.doc_index] {
+                        continue;
+                    }
+
+                    let mut selected = state.selected.clone();
+                    selected.push(token_match.clone());
+                    selected.sort_by_key(|selected_match| selected_match.query_index);
+
+                    let mut used_tokens = state.used_tokens.clone();
+                    used_tokens[token_match.doc_index] = true;
+                    let rank = Rank::from_matches(&selected, query_len, doc_len);
+
+                    next_states.push(AssignmentState {
+                        selected,
+                        used_tokens,
+                        rank,
+                    });
+                }
+            }
+
+            next_states.sort_by(Self::compare_assignment_states);
+            next_states.truncate(MAX_ASSIGNMENT_STATES);
+            states = next_states;
+        }
+
+        states.sort_by(Self::compare_assignment_states);
+        states
+            .into_iter()
+            .next()
+            .map(|state| state.selected)
+            .unwrap_or_default()
+    }
+
+    fn compare_assignment_states(lhs: &AssignmentState, rhs: &AssignmentState) -> Ordering {
+        rhs.rank
+            .score
+            .partial_cmp(&lhs.rank.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| rhs.selected.len().cmp(&lhs.selected.len()))
+            .then_with(|| {
+                let lhs_score = lhs
+                    .selected
+                    .iter()
+                    .map(|token_match| token_match.score)
+                    .sum::<f64>();
+                let rhs_score = rhs
+                    .selected
+                    .iter()
+                    .map(|token_match| token_match.score)
+                    .sum::<f64>();
+                rhs_score.partial_cmp(&lhs_score).unwrap_or(Ordering::Equal)
+            })
     }
 
     fn compare_ranked_results(&self, lhs: &RankedResult<Id>, rhs: &RankedResult<Id>) -> Ordering {
@@ -408,39 +521,260 @@ where
     }
 
     fn compare_token_matches(lhs: &TokenMatch, rhs: &TokenMatch) -> Ordering {
-        rhs.exact
-            .cmp(&lhs.exact)
-            .then_with(|| rhs.score.partial_cmp(&lhs.score).unwrap_or(Ordering::Equal))
+        rhs.score
+            .partial_cmp(&lhs.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| lhs.typo_cost.cmp(&rhs.typo_cost))
+            .then_with(|| rhs.exact.cmp(&lhs.exact))
             .then_with(|| lhs.doc_index.cmp(&rhs.doc_index))
             .then_with(|| lhs.query_index.cmp(&rhs.query_index))
     }
 
-    fn token_similarity(&self, pattern_token: &str, token: &str) -> Option<TokenSimilarity> {
-        let exact = pattern_token == token;
-        let score = jaro_winkler(token, pattern_token);
+    fn expand_query_term(&self, pattern_token: &str, prefix_search: bool) -> Vec<TermCandidate> {
+        let mut candidates: HashMap<String, TokenSimilarity> = HashMap::new();
 
-        if score > 0.0 {
-            Some(TokenSimilarity { score, exact })
-        } else {
-            None
+        if self.reverse_map.contains_key(pattern_token) {
+            Self::insert_candidate(
+                &mut candidates,
+                pattern_token,
+                TokenSimilarity {
+                    score: 1.0,
+                    typo_cost: 0,
+                    exact: true,
+                },
+            );
         }
+
+        if self.options.prefix_search && prefix_search {
+            for term in self.prefix_terms(pattern_token) {
+                if term == pattern_token {
+                    continue;
+                }
+
+                Self::insert_candidate(
+                    &mut candidates,
+                    term,
+                    TokenSimilarity {
+                        score: Self::prefix_score(pattern_token, term),
+                        typo_cost: 0,
+                        exact: false,
+                    },
+                );
+            }
+        }
+
+        if self.options.typo_tolerance {
+            for term in self.typo_terms(pattern_token) {
+                if term == pattern_token {
+                    continue;
+                }
+
+                let max_typos = Self::allowed_typos(pattern_token);
+                if let Some(typo_cost) = Self::edit_distance_at_most(pattern_token, term, max_typos)
+                {
+                    Self::insert_candidate(
+                        &mut candidates,
+                        term,
+                        TokenSimilarity {
+                            score: Self::typo_score(pattern_token, term, typo_cost),
+                            typo_cost,
+                            exact: false,
+                        },
+                    );
+                }
+            }
+        }
+
+        candidates
+            .into_iter()
+            .map(|(term, similarity)| TermCandidate { term, similarity })
+            .collect()
+    }
+
+    fn insert_candidate(
+        candidates: &mut HashMap<String, TokenSimilarity>,
+        term: &str,
+        similarity: TokenSimilarity,
+    ) {
+        candidates
+            .entry(term.to_string())
+            .and_modify(|current| {
+                if Self::compare_similarity(similarity, *current).is_lt() {
+                    *current = similarity;
+                }
+            })
+            .or_insert(similarity);
+    }
+
+    fn compare_similarity(lhs: TokenSimilarity, rhs: TokenSimilarity) -> Ordering {
+        rhs.score
+            .partial_cmp(&lhs.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| lhs.typo_cost.cmp(&rhs.typo_cost))
+            .then_with(|| rhs.exact.cmp(&lhs.exact))
+    }
+
+    fn prefix_terms(&self, prefix: &str) -> Vec<&str> {
+        if prefix.is_empty() {
+            return Vec::new();
+        }
+
+        self.terms
+            .range(prefix.to_string()..)
+            .take_while(|term| term.starts_with(prefix))
+            .map(String::as_str)
+            .collect()
+    }
+
+    fn typo_terms(&self, pattern_token: &str) -> Vec<&str> {
+        let mut terms = HashSet::new();
+        for variant in Self::deletion_variants(pattern_token, Self::allowed_typos(pattern_token)) {
+            if let Some(candidates) = self.typo_map.get(&variant) {
+                for term in candidates {
+                    terms.insert(term.as_str());
+                }
+            }
+        }
+
+        terms.into_iter().collect()
+    }
+
+    fn prefix_score(prefix: &str, term: &str) -> f64 {
+        let prefix_len = prefix.chars().count();
+        let term_len = term.chars().count().max(1);
+        0.9 + 0.1 * prefix_len as f64 / term_len as f64
+    }
+
+    fn typo_score(pattern_token: &str, term: &str, typo_cost: usize) -> f64 {
+        let len = pattern_token
+            .chars()
+            .count()
+            .max(term.chars().count())
+            .max(1);
+        1.0 - typo_cost as f64 / (len + 1) as f64
+    }
+
+    fn allowed_typos(token: &str) -> usize {
+        match token.chars().count() {
+            0..=4 => 0,
+            5..=8 => 1,
+            _ => 2,
+        }
+    }
+
+    fn add_term(&mut self, term: &str) {
+        self.terms.insert(term.to_string());
+        for variant in Self::deletion_variants(term, Self::allowed_typos(term)) {
+            self.typo_map
+                .entry(variant)
+                .or_default()
+                .insert(term.to_string());
+        }
+    }
+
+    fn remove_term(&mut self, term: &str) {
+        self.terms.remove(term);
+        for variant in Self::deletion_variants(term, Self::allowed_typos(term)) {
+            if let Some(terms) = self.typo_map.get_mut(&variant) {
+                terms.remove(term);
+                if terms.is_empty() {
+                    self.typo_map.remove(&variant);
+                }
+            }
+        }
+    }
+
+    fn deletion_variants(token: &str, max_deletions: usize) -> HashSet<String> {
+        let mut variants = HashSet::from([token.to_string()]);
+        let mut current = HashSet::from([token.to_string()]);
+
+        for _ in 0..max_deletions {
+            let mut next = HashSet::new();
+            for variant in &current {
+                let chars: Vec<char> = variant.chars().collect();
+                for index in 0..chars.len() {
+                    let mut deleted = String::with_capacity(variant.len());
+                    for (char_index, character) in chars.iter().enumerate() {
+                        if char_index != index {
+                            deleted.push(*character);
+                        }
+                    }
+                    if variants.insert(deleted.clone()) {
+                        next.insert(deleted);
+                    }
+                }
+            }
+            current = next;
+        }
+
+        variants
+    }
+
+    fn edit_distance_at_most(lhs: &str, rhs: &str, max_distance: usize) -> Option<usize> {
+        let lhs: Vec<char> = lhs.chars().collect();
+        let rhs: Vec<char> = rhs.chars().collect();
+
+        if lhs.len().abs_diff(rhs.len()) > max_distance {
+            return None;
+        }
+
+        let mut distances = vec![vec![0; rhs.len() + 1]; lhs.len() + 1];
+        for (lhs_index, row) in distances.iter_mut().enumerate() {
+            row[0] = lhs_index;
+        }
+        for (rhs_index, distance) in distances[0].iter_mut().enumerate() {
+            *distance = rhs_index;
+        }
+
+        for (lhs_index, lhs_char) in lhs.iter().enumerate() {
+            let row = lhs_index + 1;
+            let mut row_min = distances[row][0];
+
+            for (rhs_index, rhs_char) in rhs.iter().enumerate() {
+                let column = rhs_index + 1;
+                let substitution_cost = usize::from(lhs_char != rhs_char);
+                distances[row][column] = (distances[row - 1][column] + 1)
+                    .min(distances[row][column - 1] + 1)
+                    .min(distances[row - 1][column - 1] + substitution_cost);
+
+                if row > 1
+                    && column > 1
+                    && lhs[row - 1] == rhs[column - 2]
+                    && lhs[row - 2] == rhs[column - 1]
+                {
+                    distances[row][column] =
+                        distances[row][column].min(distances[row - 2][column - 2] + 1);
+                }
+
+                row_min = row_min.min(distances[row][column]);
+            }
+
+            if row_min > max_distance {
+                return None;
+            }
+        }
+
+        let distance = distances[lhs.len()][rhs.len()];
+        (distance <= max_distance).then_some(distance)
     }
 
     /// Remove an entry by id.
     pub fn remove(&mut self, id: &Id) {
-        if let Some(id_num) = self.ids_map.get(id) {
-            for token in &self.forward_map[id_num] {
-                if let Some(vec) = self.reverse_map.get_mut(token) {
-                    vec.retain(|i| i != id_num);
-                    if vec.is_empty() {
-                        // prune empty token entry to keep the index small
-                        self.reverse_map.remove(token);
+        if let Some(id_num) = self.ids_map.get(id).copied() {
+            if let Some(tokens) = self.forward_map.remove(&id_num) {
+                let unique_tokens = tokens.into_iter().collect::<HashSet<_>>();
+                for token in unique_tokens {
+                    if let Some(postings) = self.reverse_map.get_mut(&token) {
+                        postings.remove(&id_num);
+                        if postings.is_empty() {
+                            self.reverse_map.remove(&token);
+                            self.remove_term(&token);
+                        }
                     }
                 }
             }
-            self.forward_map.remove(id_num);
-            self.reverse_ids_map.remove(id_num);
             self.ids_map.remove(id);
+            self.reverse_ids_map.remove(&id_num);
         };
     }
 
@@ -451,6 +785,8 @@ where
         self.reverse_ids_map.clear();
         self.forward_map.clear();
         self.reverse_map.clear();
+        self.terms.clear();
+        self.typo_map.clear();
     }
 
     fn tokenize(&self, tokens: &[&str]) -> Vec<String> {
@@ -505,25 +841,56 @@ where
 /// use simsearch::{Options, Index};
 ///
 /// let mut engine: Index<usize> = Index::with_options(
-///     Options::new().case_sensitive(true));
+///     Options::new().limit(20));
 /// ```
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Options {
+    limit: usize,
+    prefix_search: bool,
+    typo_tolerance: bool,
     case_sensitive: bool,
     split_whitespace: bool,
     separators: Vec<String>,
-    limit: usize,
 }
 
 impl Options {
     /// Creates a default configuration.
     pub fn new() -> Self {
         Options {
+            limit: 10,
+            prefix_search: true,
+            typo_tolerance: true,
             case_sensitive: false,
             split_whitespace: true,
             separators: vec![],
-            limit: 10,
+        }
+    }
+
+    /// Sets the maximum number of results returned by a search.
+    ///
+    /// Defaults to `10`.
+    pub fn limit(self, limit: usize) -> Self {
+        Options { limit, ..self }
+    }
+
+    /// Sets whether the last query token can match indexed token prefixes.
+    ///
+    /// Defaults to `true`.
+    pub fn prefix_search(self, prefix_search: bool) -> Self {
+        Options {
+            prefix_search,
+            ..self
+        }
+    }
+
+    /// Sets whether search tolerates typos using bounded edit distance.
+    ///
+    /// Defaults to `true`.
+    pub fn typo_tolerance(self, typo_tolerance: bool) -> Self {
+        Options {
+            typo_tolerance,
+            ..self
         }
     }
 
@@ -572,13 +939,6 @@ impl Options {
     /// ```
     pub fn separators(self, separators: Vec<String>) -> Self {
         Options { separators, ..self }
-    }
-
-    /// Sets the maximum number of results returned by a search.
-    ///
-    /// Defaults to `10`.
-    pub fn limit(self, limit: usize) -> Self {
-        Options { limit, ..self }
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -142,11 +142,11 @@ fn query_terms_need_distinct_document_tokens() {
 }
 
 #[test]
-fn insert_many_searches_multiple_fields() {
+fn insert_parts_searches_multiple_parts() {
     let mut engine: Index<u32> = Index::new();
 
-    engine.insert_many(1, ["old sea", "hemingway"]);
-    engine.insert_many(2, ["old sea", "steinbeck"]);
+    engine.insert_parts(1, ["old sea", "hemingway"]);
+    engine.insert_parts(2, ["old sea", "steinbeck"]);
 
     let results = engine.search("hemingway");
 
@@ -154,12 +154,12 @@ fn insert_many_searches_multiple_fields() {
 }
 
 #[test]
-fn insert_many_updates_existing_content() {
+fn insert_parts_updates_existing_content() {
     let mut engine: Index<u32> = Index::new();
 
-    engine.insert_many(1, ["old sea", "hemingway"]);
-    engine.insert_many(2, ["hemingway"]);
-    engine.insert_many(1, ["east of eden", "steinbeck"]);
+    engine.insert_parts(1, ["old sea", "hemingway"]);
+    engine.insert_parts(2, ["hemingway"]);
+    engine.insert_parts(1, ["east of eden", "steinbeck"]);
 
     let results = engine.search("hemingway");
 
@@ -178,11 +178,11 @@ fn updating_existing_content_prunes_prefix_and_typo_terms() {
 }
 
 #[test]
-fn insert_many_uses_builtin_tokenizer() {
+fn insert_parts_uses_builtin_tokenizer() {
     let mut engine: Index<u32> =
         Index::with_options(Options::new().separators(vec!["/".to_string()]));
 
-    engine.insert_many(1, ["old/man"]);
+    engine.insert_parts(1, ["old/man"]);
 
     let split_results = engine.search("old man");
     let token_results = engine.search("old/man");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -179,12 +179,7 @@ fn updating_existing_content_prunes_prefix_and_typo_terms() {
 
 #[test]
 fn insert_parts_uses_builtin_tokenizer() {
-    let mut separators: Vec<char> = (0..=u8::MAX)
-        .map(char::from)
-        .filter(char::is_ascii_whitespace)
-        .collect();
-    separators.push('/');
-    let mut engine: Index<u32> = Index::with_options(Options::new().separators(separators));
+    let mut engine: Index<u32> = Index::with_options(Options::new().separators(['/']));
 
     engine.insert_parts(1, ["old/man"]);
 
@@ -196,17 +191,20 @@ fn insert_parts_uses_builtin_tokenizer() {
 }
 
 #[test]
-fn separators_replace_default_separators() {
+fn separators_keep_whitespace_and_add_extra_separators() {
     let mut engine: Index<u32> = Index::with_options(Options::new().separators(vec!['/']));
 
     engine.insert(1, "old/man");
-    engine.insert(2, "old man");
+    engine.insert(2, "new world");
+    engine.insert(3, "unicode\u{2003}space");
 
-    let split_results = ids(engine.search("old/man"));
-    let unsplit_results = ids(engine.search("old man"));
+    let slash_results = ids(engine.search("old man"));
+    let whitespace_results = ids(engine.search("new world"));
+    let unicode_whitespace_results = ids(engine.search("unicode space"));
 
-    assert_eq!(split_results[0], 1);
-    assert_eq!(unsplit_results[0], 2);
+    assert_eq!(slash_results[0], 1);
+    assert_eq!(whitespace_results[0], 2);
+    assert_eq!(unicode_whitespace_results[0], 3);
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -194,6 +194,60 @@ fn limit_caps_results() {
 }
 
 #[test]
+fn exact_full_match_ranks_before_longer_match() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "apple banana");
+    engine.insert(2, "apple");
+
+    let results = engine.search("apple");
+
+    assert_eq!(results[0].id, 2);
+    assert!(results[0].score > results[1].score);
+}
+
+#[test]
+fn exact_full_match_survives_default_limit() {
+    let mut engine: Index<u32> = Index::new();
+
+    for id in 0..10 {
+        engine.insert(id, "apple banana");
+    }
+    engine.insert(10, "apple");
+
+    let results = ids(engine.search("apple"));
+
+    assert_eq!(results[0], 10);
+    assert!(results.contains(&10));
+}
+
+#[test]
+fn exact_query_terms_keep_their_matching_document_tokens() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "ac ab");
+    engine.insert(2, "ab ad");
+
+    let results = engine.search("ax ac");
+
+    assert_eq!(results[0].id, 1);
+    assert!(results[0].score > results[1].score);
+}
+
+#[test]
+fn strong_fuzzy_matches_are_assigned_before_weaker_matches() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "ae abac");
+    engine.insert(2, "abac ae");
+
+    let results = engine.search("aa ab");
+
+    assert_eq!(results[0].id, 1);
+    assert!(results[0].score > results[1].score);
+}
+
+#[test]
 fn exact_tokens_rank_before_typos() {
     let mut engine: Index<u32> = Index::new();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -116,6 +116,26 @@ fn near_tokens_rank_before_far_tokens() {
 }
 
 #[test]
+fn adjacent_phrase_with_many_repeated_tokens_ranks_before_far_match() {
+    let mut engine: Index<u32> = Index::new();
+    let mut phrase_doc = vec!["a"; 100];
+    phrase_doc.extend(["a", "b"]);
+    phrase_doc.extend(vec!["b"; 101]);
+
+    let mut far_doc = vec!["a"];
+    far_doc.extend(vec!["x"; 20]);
+    far_doc.push("b");
+
+    engine.insert(1, &phrase_doc.join(" "));
+    engine.insert(2, &far_doc.join(" "));
+
+    let results = engine.search("a b");
+
+    assert_eq!(results[0].id, 1);
+    assert!(results[0].score > results[1].score);
+}
+
+#[test]
 fn equal_ranks_keep_insertion_order_without_ord_ids() {
     let mut engine: Index<StableId> = Index::new();
     let first = StableId("first");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -150,6 +150,19 @@ fn equal_ranks_keep_insertion_order_without_ord_ids() {
 }
 
 #[test]
+fn updating_existing_content_preserves_insertion_order() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "apple");
+    engine.insert(2, "apple");
+    engine.insert(1, "apple");
+
+    let results = ids(engine.search("apple"));
+
+    assert_eq!(results, vec![1, 2]);
+}
+
+#[test]
 fn query_terms_need_distinct_document_tokens() {
     let mut engine: Index<u32> = Index::new();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -53,6 +53,18 @@ fn remove_prunes_reverse_map_entries() {
 }
 
 #[test]
+fn duplicate_tokens_are_indexed_once_per_entry() {
+    let mut engine: Index<String> = Index::new();
+    let id = "id1".to_string();
+
+    engine.insert(id.clone(), "apple apple");
+    engine.remove(&id);
+
+    let results = engine.search("apple");
+    assert!(results.is_empty());
+}
+
+#[test]
 fn search_returns_normalized_scores() {
     let mut engine: Index<u32> = Index::new();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -17,7 +17,7 @@ fn populate_engine() -> Index<String> {
         .iter()
         .map(|v| v.as_str().unwrap().to_string())
         .collect::<Vec<_>>();
-    let mut engine = Index::with_options(Options::new().split_whitespace(true));
+    let mut engine = Index::new();
 
     for title in books {
         engine.insert(title.clone(), &title);
@@ -179,8 +179,12 @@ fn updating_existing_content_prunes_prefix_and_typo_terms() {
 
 #[test]
 fn insert_parts_uses_builtin_tokenizer() {
-    let mut engine: Index<u32> =
-        Index::with_options(Options::new().separators(vec!["/".to_string()]));
+    let mut separators: Vec<char> = (0..=u8::MAX)
+        .map(char::from)
+        .filter(char::is_ascii_whitespace)
+        .collect();
+    separators.push('/');
+    let mut engine: Index<u32> = Index::with_options(Options::new().separators(separators));
 
     engine.insert_parts(1, ["old/man"]);
 
@@ -189,6 +193,20 @@ fn insert_parts_uses_builtin_tokenizer() {
 
     assert_eq!(split_results[0].id, 1);
     assert_eq!(token_results[0].id, 1);
+}
+
+#[test]
+fn separators_replace_default_separators() {
+    let mut engine: Index<u32> = Index::with_options(Options::new().separators(vec!['/']));
+
+    engine.insert(1, "old/man");
+    engine.insert(2, "old man");
+
+    let split_results = ids(engine.search("old/man"));
+    let unsplit_results = ids(engine.search("old man"));
+
+    assert_eq!(split_results[0], 1);
+    assert_eq!(unsplit_results[0], 2);
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -332,6 +332,28 @@ fn last_query_term_matches_prefixes() {
 }
 
 #[test]
+fn last_query_term_matches_typo_prefixes() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "things fall apart");
+
+    let results = ids(engine.search("thng"));
+
+    assert_eq!(results, vec![1]);
+}
+
+#[test]
+fn typo_prefixes_use_prefix_search_option() {
+    let mut engine: Index<u32> = Index::with_options(Options::new().prefix_search(false));
+
+    engine.insert(1, "things fall apart");
+
+    let results = engine.search("thng");
+
+    assert!(results.is_empty());
+}
+
+#[test]
 fn prefix_search_can_be_disabled() {
     let mut engine: Index<u32> = Index::with_options(Options::new().prefix_search(false));
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -173,7 +173,7 @@ fn updating_existing_content_prunes_prefix_and_typo_terms() {
     engine.insert(1, "things");
     engine.insert(1, "other");
 
-    assert!(engine.search("thi").is_empty());
+    assert!(engine.search("things").is_empty());
     assert!(engine.search("thngs").is_empty());
 }
 
@@ -343,8 +343,30 @@ fn last_query_term_matches_typo_prefixes() {
 }
 
 #[test]
-fn typo_prefixes_use_prefix_search_option() {
-    let mut engine: Index<u32> = Index::with_options(Options::new().prefix_search(false));
+fn short_transposed_typos_can_match() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "old sea");
+
+    let results = ids(engine.search("odl"));
+
+    assert_eq!(results, vec![1]);
+}
+
+#[test]
+fn long_words_tolerate_multiple_typos() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "internationalization");
+
+    let results = ids(engine.search("internatoinaliztion"));
+
+    assert_eq!(results, vec![1]);
+}
+
+#[test]
+fn typo_prefixes_use_typo_tolerance_option() {
+    let mut engine: Index<u32> = Index::with_options(Options::new().typo_tolerance(false));
 
     engine.insert(1, "things fall apart");
 
@@ -355,7 +377,8 @@ fn typo_prefixes_use_prefix_search_option() {
 
 #[test]
 fn prefix_search_can_be_disabled() {
-    let mut engine: Index<u32> = Index::with_options(Options::new().prefix_search(false));
+    let mut engine: Index<u32> =
+        Index::with_options(Options::new().prefix_search(false).typo_tolerance(false));
 
     engine.insert(1, "search");
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -53,18 +53,6 @@ fn remove_prunes_reverse_map_entries() {
 }
 
 #[test]
-fn duplicate_tokens_are_indexed_once_per_entry() {
-    let mut engine: Index<String> = Index::new();
-    let id = "id1".to_string();
-
-    engine.insert(id.clone(), "apple apple");
-    engine.remove(&id);
-
-    let results = engine.search("apple");
-    assert!(results.is_empty());
-}
-
-#[test]
 fn search_returns_normalized_scores() {
     let mut engine: Index<u32> = Index::new();
 
@@ -179,6 +167,17 @@ fn insert_many_updates_existing_content() {
 }
 
 #[test]
+fn updating_existing_content_prunes_prefix_and_typo_terms() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "things");
+    engine.insert(1, "other");
+
+    assert!(engine.search("thi").is_empty());
+    assert!(engine.search("thngs").is_empty());
+}
+
+#[test]
 fn insert_many_uses_builtin_tokenizer() {
     let mut engine: Index<u32> =
         Index::with_options(Options::new().separators(vec!["/".to_string()]));
@@ -234,15 +233,149 @@ fn exact_full_match_survives_default_limit() {
 }
 
 #[test]
+fn exact_full_match_survives_small_limit() {
+    let mut engine: Index<u32> = Index::with_options(Options::new().limit(1));
+
+    for id in 0..40 {
+        engine.insert(id, "apple banana");
+    }
+    engine.insert(40, "apple");
+
+    let results = ids(engine.search("apple"));
+
+    assert_eq!(results, vec![40]);
+}
+
+#[test]
+fn multi_term_match_survives_small_limit() {
+    let mut engine: Index<u32> = Index::with_options(Options::new().limit(1));
+
+    for id in 0..40 {
+        engine.insert(id, "apple");
+    }
+    engine.insert(40, "apple banana");
+
+    let results = ids(engine.search("apple banana"));
+
+    assert_eq!(results, vec![40]);
+}
+
+#[test]
+fn duplicate_query_terms_need_distinct_document_tokens_before_limit() {
+    let mut engine: Index<u32> = Index::with_options(Options::new().limit(1));
+
+    for id in 0..40 {
+        engine.insert(id, "apple");
+    }
+    engine.insert(40, "apple apple");
+
+    let results = ids(engine.search("apple apple"));
+
+    assert_eq!(results, vec![40]);
+}
+
+#[test]
+fn duplicate_query_terms_can_use_long_queries() {
+    let mut engine: Index<u32> = Index::new();
+    let eight_apples = ["apple"; 8].join(" ");
+    let many_apples = ["apple"; 16].join(" ");
+
+    engine.insert(1, &eight_apples);
+    engine.insert(2, &many_apples);
+
+    let results = ids(engine.search(&many_apples));
+
+    assert_eq!(results[0], 2);
+}
+
+#[test]
+fn duplicate_query_terms_can_match_later_document_tokens() {
+    let mut engine: Index<u32> = Index::new();
+    let leading = ["a"; 16].join(" ");
+    let trailing = ["a"; 15].join(" ");
+    let full = format!("{leading} x {trailing}");
+    let partial = format!("x {}", ["a"; 14].join(" "));
+    let query = format!("x {trailing}");
+
+    engine.insert(1, &full);
+    engine.insert(2, &partial);
+
+    let results = ids(engine.search(&query));
+
+    assert_eq!(results[0], 1);
+}
+
+#[test]
+fn search_uses_late_query_terms() {
+    let mut engine: Index<u32> = Index::new();
+    let mut query_terms = (0..16)
+        .map(|index| format!("aaaaaaaa{index:02}"))
+        .collect::<Vec<_>>();
+    query_terms.push("zzzzzzzz".to_string());
+
+    engine.insert(1, "zzzzzzzz");
+
+    let results = ids(engine.search(&query_terms.join(" ")));
+
+    assert_eq!(results[0], 1);
+}
+
+#[test]
+fn last_query_term_matches_prefixes() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "old sea");
+
+    let results = ids(engine.search("old se"));
+
+    assert_eq!(results, vec![1]);
+}
+
+#[test]
+fn prefix_search_can_be_disabled() {
+    let mut engine: Index<u32> = Index::with_options(Options::new().prefix_search(false));
+
+    engine.insert(1, "search");
+
+    let results = engine.search("sea");
+
+    assert!(results.is_empty());
+}
+
+#[test]
+fn typo_tolerance_can_be_disabled() {
+    let mut engine: Index<u32> = Index::with_options(Options::new().typo_tolerance(false));
+
+    engine.insert(1, "things");
+
+    let results = engine.search("thngs");
+
+    assert!(results.is_empty());
+}
+
+#[test]
 fn exact_query_terms_keep_their_matching_document_tokens() {
     let mut engine: Index<u32> = Index::new();
 
-    engine.insert(1, "ac ab");
-    engine.insert(2, "ab ad");
+    engine.insert(1, "alpha alpgb");
+    engine.insert(2, "alpha");
 
-    let results = engine.search("ax ac");
+    let results = engine.search("alpga alpha");
 
     assert_eq!(results[0].id, 1);
+    assert!(results[0].score > results[1].score);
+}
+
+#[test]
+fn assignment_can_move_strong_fuzzy_match_to_cover_more_query_terms() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "alphabet");
+    engine.insert(2, "alphabet alphabeta");
+
+    let results = engine.search("alphabeta alphabet");
+
+    assert_eq!(results[0].id, 2);
     assert!(results[0].score > results[1].score);
 }
 
@@ -250,23 +383,10 @@ fn exact_query_terms_keep_their_matching_document_tokens() {
 fn strong_fuzzy_matches_are_assigned_before_weaker_matches() {
     let mut engine: Index<u32> = Index::new();
 
-    engine.insert(1, "ae abac");
-    engine.insert(2, "abac ae");
+    engine.insert(1, "alphx betaa");
+    engine.insert(2, "betaa alphx");
 
-    let results = engine.search("aa ab");
-
-    assert_eq!(results[0].id, 1);
-    assert!(results[0].score > results[1].score);
-}
-
-#[test]
-fn token_assignment_uses_higher_similarity_for_fuzzy_matches() {
-    let mut engine: Index<u32> = Index::new();
-
-    engine.insert(1, "ac abxxxxxxxxxxxxxxx");
-    engine.insert(2, "ac");
-
-    let results = engine.search("ab");
+    let results = engine.search("alpha beta");
 
     assert_eq!(results[0].id, 1);
     assert!(results[0].score > results[1].score);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -260,6 +260,19 @@ fn strong_fuzzy_matches_are_assigned_before_weaker_matches() {
 }
 
 #[test]
+fn token_assignment_uses_higher_similarity_for_fuzzy_matches() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "ac abxxxxxxxxxxxxxxx");
+    engine.insert(2, "ac");
+
+    let results = engine.search("ab");
+
+    assert_eq!(results[0].id, 1);
+    assert!(results[0].score > results[1].score);
+}
+
+#[test]
 fn exact_tokens_rank_before_typos() {
     let mut engine: Index<u32> = Index::new();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,11 +1,14 @@
 use std::{fs::File, sync::LazyLock};
 
 use quickcheck_macros::quickcheck;
-use simsearch::{SearchOptions, SimSearch};
+use simsearch::{Hit, Index, Options};
 
-static ENGINE: LazyLock<SimSearch<String>> = LazyLock::new(populate_engine);
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct StableId(&'static str);
 
-fn populate_engine() -> SimSearch<String> {
+static ENGINE: LazyLock<Index<String>> = LazyLock::new(populate_engine);
+
+fn populate_engine() -> Index<String> {
     let mut file = File::open("./books.json").unwrap();
     let json: serde_json::Value = serde_json::from_reader(&mut file).unwrap();
     let books = json
@@ -14,13 +17,17 @@ fn populate_engine() -> SimSearch<String> {
         .iter()
         .map(|v| v.as_str().unwrap().to_string())
         .collect::<Vec<_>>();
-    let mut engine = SimSearch::new_with(SearchOptions::new().stop_whitespace(true));
+    let mut engine = Index::with_options(Options::new().split_whitespace(true));
 
     for title in books {
         engine.insert(title.clone(), &title);
     }
 
     engine
+}
+
+fn ids<Id>(hits: Vec<Hit<Id>>) -> Vec<Id> {
+    hits.into_iter().map(|hit| hit.id).collect()
 }
 
 #[quickcheck]
@@ -30,60 +37,196 @@ fn test_quickcheck(tokens: Vec<String>) {
 
 #[test]
 fn remove_prunes_reverse_map_entries() {
-    let mut engine: SimSearch<String> = SimSearch::new();
+    let mut engine: Index<String> = Index::new();
     let id = "id1".to_string();
 
     engine.insert(id.clone(), "unique-token");
     // ensure present
-    let res = engine.search("unique-token");
+    let res = ids(engine.search("unique-token"));
     assert_eq!(res, vec![id.clone()]);
 
     engine.remove(&id);
 
     // after removal the token should no longer be found
-    let res2: Vec<String> = engine.search("unique-token");
+    let res2 = engine.search("unique-token");
     assert!(res2.is_empty());
 }
 
 #[test]
-fn search_with_scores_returns_ids_and_scores() {
-    let mut engine: SimSearch<u32> = SimSearch::new();
+fn search_returns_normalized_scores() {
+    let mut engine: Index<u32> = Index::new();
 
-    engine.insert(1, "Things Fall Apart");
+    engine.insert(1, "old man and the sea");
+    engine.insert(2, "old sea");
 
-    let results = engine.search_with_scores("thngs");
+    let results = engine.search("old sea");
 
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].0, 1);
-    assert!(results[0].1 > 0.0);
+    assert_eq!(results[0].id, 2);
+    assert!(
+        results
+            .iter()
+            .all(|result| (0.0..=1.0).contains(&result.score))
+    );
+    assert!(results[0].score >= results[1].score);
 }
 
 #[test]
-fn search_keeps_same_order_as_scored_search() {
-    let mut engine: SimSearch<u32> = SimSearch::new_with(SearchOptions::new().threshold(0.0));
+fn search_results_are_sorted_by_score() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "old sea");
+    engine.insert(2, "sea old");
+    engine.insert(3, "old man and the sea");
+
+    let results = engine.search("old sea");
+
+    assert!(
+        results
+            .windows(2)
+            .all(|pair| pair[0].score >= pair[1].score)
+    );
+    assert_eq!(
+        results.iter().map(|result| result.id).collect::<Vec<_>>(),
+        ids(engine.search("old sea"))
+    );
+}
+
+#[test]
+fn ordered_tokens_rank_before_reversed_tokens() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "old sea");
+    engine.insert(2, "sea old");
+
+    let results = ids(engine.search("old sea"));
+
+    assert_eq!(results, vec![1, 2]);
+}
+
+#[test]
+fn near_tokens_rank_before_far_tokens() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "old sea");
+    engine.insert(2, "old man and the sea");
+
+    let results = ids(engine.search("old sea"));
+
+    assert_eq!(results, vec![1, 2]);
+}
+
+#[test]
+fn equal_ranks_keep_insertion_order_without_ord_ids() {
+    let mut engine: Index<StableId> = Index::new();
+    let first = StableId("first");
+    let second = StableId("second");
+
+    engine.insert(first.clone(), "apple");
+    engine.insert(second.clone(), "apple");
+
+    let results = ids(engine.search("apple"));
+
+    assert_eq!(results, vec![first, second]);
+}
+
+#[test]
+fn query_terms_need_distinct_document_tokens() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "new york");
+    engine.insert(2, "newyork");
+
+    let results = engine.search("new york");
+
+    assert_eq!(results[0].id, 1);
+}
+
+#[test]
+fn insert_many_searches_multiple_fields() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert_many(1, ["old sea", "hemingway"]);
+    engine.insert_many(2, ["old sea", "steinbeck"]);
+
+    let results = engine.search("hemingway");
+
+    assert_eq!(results[0].id, 1);
+}
+
+#[test]
+fn insert_many_updates_existing_content() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert_many(1, ["old sea", "hemingway"]);
+    engine.insert_many(2, ["hemingway"]);
+    engine.insert_many(1, ["east of eden", "steinbeck"]);
+
+    let results = engine.search("hemingway");
+
+    assert_eq!(results[0].id, 2);
+}
+
+#[test]
+fn insert_many_uses_builtin_tokenizer() {
+    let mut engine: Index<u32> =
+        Index::with_options(Options::new().separators(vec!["/".to_string()]));
+
+    engine.insert_many(1, ["old/man"]);
+
+    let split_results = engine.search("old man");
+    let token_results = engine.search("old/man");
+
+    assert_eq!(split_results[0].id, 1);
+    assert_eq!(token_results[0].id, 1);
+}
+
+#[test]
+fn limit_caps_results() {
+    let mut engine: Index<u32> = Index::with_options(Options::new().limit(1));
 
     engine.insert(1, "apple");
-    engine.insert(2, "apples");
-    engine.insert(3, "banana");
+    engine.insert(2, "apple");
 
-    let ids = engine.search("apple");
-    let scored_ids = engine
-        .search_with_scores("apple")
-        .into_iter()
-        .map(|(id, _score)| id)
-        .collect::<Vec<_>>();
+    let results = engine.search("apple");
 
-    assert_eq!(ids, scored_ids);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, 1);
 }
 
 #[test]
-fn token_score_uses_best_pattern_token_match() {
-    let mut engine: SimSearch<u32> = SimSearch::new_with(SearchOptions::new().threshold(0.0));
+fn exact_tokens_rank_before_typos() {
+    let mut engine: Index<u32> = Index::new();
 
-    engine.insert(1, "foo");
+    engine.insert(1, "apple");
+    engine.insert(2, "appel");
 
-    let bad_then_exact = engine.search_tokens_with_scores(&["bar", "foo"])[0].1;
-    let exact_then_bad = engine.search_tokens_with_scores(&["foo", "bar"])[0].1;
+    let results = engine.search("apple");
 
-    assert_eq!(bad_then_exact, exact_then_bad);
+    assert_eq!(results[0].id, 1);
+}
+
+#[test]
+fn partial_matches_are_allowed_with_lower_scores() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "old man");
+
+    let results = engine.search("old missing");
+
+    assert_eq!(results[0].id, 1);
+    assert!(results[0].score > 0.0);
+    assert!(results[0].score < 1.0);
+}
+
+#[test]
+fn exact_tokens_rank_before_typos_with_higher_scores() {
+    let mut engine: Index<u32> = Index::new();
+
+    engine.insert(1, "alpha");
+    engine.insert(2, "alpah");
+
+    let results = engine.search("alpha");
+
+    assert_eq!(results[0].id, 1);
+    assert!(results[0].score > results[1].score);
 }


### PR DESCRIPTION
## Summary

- Redesign the public API around `Index`, `Options`, and `Hit`, with `search(...)` returning scored hits for embedded autocomplete use cases.
- Add `Options::limit(...)` with a default result cap of 10, and replace custom token APIs with `insert_parts(...)` for multi-part documents.
- Remove threshold filtering and configurable matching metrics; search now uses exact matching, last-token prefix matching, Jaro-Winkler typo tolerance, and one normalized relevance score.
- Update README, benchmarks, the books example, tests, and add a changelog with migration notes.

## Design Notes

This is a breaking API cleanup for `0.4.0`. The new ranking keeps low-quality matches available but sorts by one normalized score that accounts for token quality, coverage, proximity, exactness, position, and document specificity.

Search uses a positional inverted index. Query terms expand to exact, last-token prefix, Jaro-Winkler typo-tolerant term, and typo-tolerant prefix candidates before deterministic document ranking.

Closes #20.
