### PR TITLE
ci: simplify CI badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
-name: Continuous integration
+name: CI
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `simsearch`
 
-[![Continuous integration](https://github.com/andylokandy/simsearch-rs/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/andylokandy/simsearch-rs/actions/workflows/ci.yml)
+[![CI](https://github.com/andylokandy/simsearch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/andylokandy/simsearch/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/simsearch.svg)](https://crates.io/crates/simsearch)
 [![docs.rs](https://docs.rs/simsearch/badge.svg)](https://docs.rs/simsearch)
 [![MSRV 1.85.0](https://img.shields.io/badge/MSRV-1.85.0-green?style=flat-square&logo=rust)](https://www.whatrustisit.com)


### PR DESCRIPTION
## Summary

- Rename the workflow badge label to CI.
- Point the README badge at the current repository and main branch.
- Update CI branch filters from master to main.